### PR TITLE
Replaced plain code generation with KotlinPoet

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 kotlin = "1.9.20"
 kotlinx-serialization = "1.6.3"
+kotlinPoet = "1.16.0"
 gradle-buildconfig = "5.3.5"
 detekt = "1.23.3"
 gson = "2.10.1"
@@ -15,6 +16,7 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 
 [libraries]
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+kotlinPoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinPoet" }
 detekt = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 kotest-assertions-core-jvm = { module = "io.kotest:kotest-assertions-core-jvm", version.ref = "kotest" }

--- a/linguine-generator/build.gradle.kts
+++ b/linguine-generator/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
     implementation(libs.gson)
     implementation(kotlin("gradle-plugin"))
     implementation(kotlin("stdlib"))
+    implementation(libs.kotlinPoet)
     testImplementation(gradleTestKit())
     testImplementation(kotlin("test-junit5"))
     testImplementation(libs.kotest.assertions.core.jvm)

--- a/linguine-generator/src/functionalTest/kotlin/com/qinshift/linguine/linguinegenerator/FileContentGeneratorTest.kt
+++ b/linguine-generator/src/functionalTest/kotlin/com/qinshift/linguine/linguinegenerator/FileContentGeneratorTest.kt
@@ -25,15 +25,18 @@ class FileContentGeneratorTest {
         )
         val generator = FileContentGenerator(fileContent)
 
-        val result = generator.generateFileContent(root).toString()
+        val result = generator.generateFileContent(root)
 
         val expected = """
             import com.qinshift.linguine.linguineruntime.presentation.Localiser.localise
+            import kotlin.String
             
             public object Strings {
                 public object Settings {
                     public val privacy: String = localise("settings__privacy")
+            
                     public val title: String = localise("settings__title")
+            
                     public object Privacy {
                         public val title: String = localise("settings__privacy__title")
                     }
@@ -56,10 +59,11 @@ class FileContentGeneratorTest {
         )
         val generator = FileContentGenerator(fileContent)
 
-        val result = generator.generateFileContent(root).toString()
+        val result = generator.generateFileContent(root)
 
         val expected = """
             import com.qinshift.linguine.linguineruntime.presentation.Localiser.localise
+            import kotlin.String
             
             public object Strings {
                 public object Section {
@@ -89,17 +93,19 @@ class FileContentGeneratorTest {
         )
         val generator = FileContentGenerator(fileContent)
 
-        val result = generator.generateFileContent(root).toString()
+        val result = generator.generateFileContent(root)
 
         val expected = """
             import com.qinshift.linguine.linguineruntime.presentation.Localiser.localise
+            import kotlin.String
             
             public object Strings {
                 public object Deep {
                     public object LevelOne {
                         public object LevelTwo {
                             public object LevelThree {
-                                public val final: String = localise("deep__level_one__level_two__level_three__final")
+                                public val `final`: String =
+                                        localise("deep__level_one__level_two__level_three__final")
                             }
                         }
                     }
@@ -122,13 +128,15 @@ class FileContentGeneratorTest {
         )
         val generator = FileContentGenerator(fileContent)
 
-        val result = generator.generateFileContent(root).toString()
+        val result = generator.generateFileContent(root)
 
         val expected = """
             import com.qinshift.linguine.linguineruntime.presentation.Localiser.localise
+            import kotlin.String
             
             public object Strings {
                 public val Simple: String = localise("simple__key")
+            
                 public val AnotherSimple: String = localise("another__simple__key")
             }
         """
@@ -148,16 +156,21 @@ class FileContentGeneratorTest {
         )
         val generator = FileContentGenerator(fileContent)
 
-        val result = generator.generateFileContent(root).toString()
+        val result = generator.generateFileContent(root)
 
         val expected = """
             import com.qinshift.linguine.linguineruntime.presentation.Localiser.localise
+            import kotlin.Int
+            import kotlin.String
             
             public object Strings {
                 public object Error {
-                    public fun messageWithParameters(param0: String, param1: Int, param2: Int, param3: String): String {
-                        return localise("error__message__with_parameters", param0, param1, param2, param3)
-                    }
+                    public fun messageWithParameters(
+                        param1: String,
+                        param2: Int,
+                        param3: Int,
+                        param4: String,
+                    ): String = localise("error__message__with_parameters", param1, param2, param3, param4)
                 }
             }
         """
@@ -185,20 +198,23 @@ class FileContentGeneratorTest {
         )
         val generator = FileContentGenerator(fileContent)
 
-        val result = generator.generateFileContent(root).toString()
+        val result = generator.generateFileContent(root)
 
         val expected = """
             import com.qinshift.linguine.linguineruntime.presentation.Localiser.localise
+            import kotlin.String
             
             public object Strings {
                 public object Special {
                     public object Characters {
                         public object Key {
-                            public val value: String = localise("special__char@cters__key!__value")
+                            public val `value`: String = localise("special__char@cters__key!__value")
                         }
                     }
+            
                     public object AnotherSpecial {
-                        public val keyWithNumbers123: String = localise("another__special__key__with_numbers123")
+                        public val keyWithNumbers123: String =
+                                localise("another__special__key__with_numbers123")
                     }
                 }
             }
@@ -252,36 +268,47 @@ class FileContentGeneratorTest {
         )
         val generator = FileContentGenerator(fileContent)
 
-        val result = generator.generateFileContent(root).toString()
+        val result = generator.generateFileContent(root)
 
         val expected = """
             import com.qinshift.linguine.linguineruntime.presentation.Localiser.localise
+            import kotlin.String
             
             public object Strings {
                 public object Activation {
                     public object ForgottenPassword {
-                        public object Birthdate {
-                            public val cancelButton: String = localise("activation__forgotten_password__birthdate__cancel_button")
-                        }
                         public val emailInput: String = localise("activation__forgotten_password__email_input")
+            
+                        public object Birthdate {
+                            public val cancelButton: String =
+                                    localise("activation__forgotten_password__birthdate__cancel_button")
+                        }
                     }
                 }
+            
                 public object Home {
                     public val welcomeMessage: String = localise("home__welcome_message")
                 }
+            
                 public object Profile {
                     public object Settings {
                         public object Privacy {
                             public val title: String = localise("profile__settings__privacy__title")
+            
                             public val description: String = localise("profile__settings__privacy__description")
                         }
                     }
                 }
+            
                 public object Checkout {
                     public object Payment {
                         public object CreditCard {
-                            public val numberInput: String = localise("checkout__payment__credit_card__number_input")
-                            public val expiryDate: String = localise("checkout__payment__credit_card__expiry_date")
+                            public val numberInput: String =
+                                    localise("checkout__payment__credit_card__number_input")
+            
+                            public val expiryDate: String =
+                                    localise("checkout__payment__credit_card__expiry_date")
+            
                             public val cvv: String = localise("checkout__payment__credit_card__cvv")
                         }
                     }
@@ -308,18 +335,27 @@ class FileContentGeneratorTest {
         )
         val generator = FileContentGenerator(fileContent)
 
-        val result = generator.generateFileContent(root).toString()
+        val result = generator.generateFileContent(root)
 
         val expected = """
             import com.qinshift.linguine.linguineruntime.presentation.Localiser.localise
+            import kotlin.Float
+            import kotlin.Int
+            import kotlin.String
             
             public object Strings {
                 public object Activation {
                     public object ForgottenPassword {
                         public object Birthdate {
-                            public fun cancelButton(param0: String, param1: Int, param2: Float, param3: String, param4: Int, param5: Float): String {
-                                return localise("activation__forgotten_password__birthdate__cancel_button", param0, param1, param2, param3, param4, param5)
-                            }
+                            public fun cancelButton(
+                                param1: String,
+                                param2: Int,
+                                param3: Float,
+                                param4: String,
+                                param5: Int,
+                                param6: Float,
+                            ): String = localise("activation__forgotten_password__birthdate__cancel_button",
+                                    param1, param2, param3, param4, param5, param6)
                         }
                     }
                 }

--- a/linguine-generator/src/functionalTest/kotlin/com/qinshift/linguine/linguinegenerator/FileWriterTest.kt
+++ b/linguine-generator/src/functionalTest/kotlin/com/qinshift/linguine/linguinegenerator/FileWriterTest.kt
@@ -1,11 +1,11 @@
 package com.qinshift.linguine.linguinegenerator
 
 import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import java.io.File
 import java.nio.file.Path
 import kotlin.test.BeforeTest
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.io.TempDir
 
 class FileWriterTest {
 
@@ -28,22 +28,22 @@ class FileWriterTest {
     @Test
     fun `writeToFile writes correct text to the file`() {
         val testFile = File(tempDir.toFile(), "testFileWriter.kt")
-        val testContent = StringBuilder("This is a test string to be written\n.")
+        val testContent = "This is a test string to be written\n."
 
         fileWriter.writeToFile(testFile, testContent)
 
-        assertFileContentMatches(testFile, testContent.toString())
+        assertFileContentMatches(testFile, testContent)
     }
 
     @Test
     fun `writeToFile should create file if it does not exist`() {
         val nonExistentFile = File(tempDir.toFile(), "nonexistent/subdirectory/testFile.txt")
-        val contentToWrite = StringBuilder("Test content")
+        val contentToWrite = "Test content"
 
         nonExistentFile.exists() shouldBe false
 
         fileWriter.writeToFile(nonExistentFile, contentToWrite)
 
-        assertFileContentMatches(nonExistentFile, contentToWrite.toString())
+        assertFileContentMatches(nonExistentFile, contentToWrite)
     }
 }

--- a/linguine-generator/src/functionalTest/kotlin/com/qinshift/linguine/linguinegenerator/LinguinePluginFunctionalTest.kt
+++ b/linguine-generator/src/functionalTest/kotlin/com/qinshift/linguine/linguinegenerator/LinguinePluginFunctionalTest.kt
@@ -100,20 +100,31 @@ class LinguinePluginFunctionalTest {
         val actualContent = generatedFile.readText()
         val expectedContent = """
             import com.qinshift.linguine.linguineruntime.presentation.Localiser.localise
+            import kotlin.Float
+            import kotlin.Int
+            import kotlin.String
             
             public object Strings {
                 public object Activation {
                     public object ForgottenPassword {
                         public object Birthdate {
-                            public val logIn: String = localise("activation__forgotten_password__birthdate__log_in")
-                            public fun logOut(param0: String, param1: Int, param2: Float, param3: String, param4: Int, param5: Float): String {
-                                return localise("activation__forgotten_password__birthdate__log_out", param0, param1, param2, param3, param4, param5)
-                            }
+                            public val logIn: String =
+                                    localise("activation__forgotten_password__birthdate__log_in")
+            
+                            public fun logOut(
+                                param1: String,
+                                param2: Int,
+                                param3: Float,
+                                param4: String,
+                                param5: Int,
+                                param6: Float,
+                            ): String = localise("activation__forgotten_password__birthdate__log_out", param1,
+                                    param2, param3, param4, param5, param6)
                         }
                     }
                 }
             }
-            
+        
         """.trimIndent()
         kotlin.test.assertEquals(
             expectedContent,

--- a/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/FileContentGenerator.kt
+++ b/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/FileContentGenerator.kt
@@ -1,108 +1,97 @@
 package com.qinshift.linguine.linguinegenerator
 
-class FileContentGenerator(private val fileContent: Map<String, String>) {
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeSpec
+import kotlin.reflect.KClass
+
+class FileContentGenerator(
+    private val fileContent: Map<String, String>,
+) {
 
     private companion object {
         const val DEFAULT_INDENT = "    "
         val FORMAT_SPECIFIER_REGEX = Regex("%[0-9]*\\\$[sdf]|%[sdf]")
     }
 
-    fun generateFileContent(root: Map<String, Any>): StringBuilder {
-        val stringBuilder = StringBuilder()
-
-        stringBuilder.apply {
-            append("import com.qinshift.linguine.linguineruntime.presentation.Localiser.localise\n\n")
-            append("public object Strings {\n")
-            generateKotlinCode(stringBuilder, root, 1)
-            append("}\n")
-        }
-        return stringBuilder
+    fun generateFileContent(root: Map<String, Any>): String {
+        return FileSpec.builder("", "")
+            .indent(DEFAULT_INDENT)
+            .addImport(
+                "com.qinshift.linguine.linguineruntime.presentation",
+                "Localiser.localise",
+            )
+            .addType(
+                TypeSpec.objectBuilder("Strings")
+                    .addObjectContent(root)
+                    .build(),
+            )
+            .build()
+            .toString()
     }
 
-    private fun generateKotlinCode(builder: StringBuilder, map: Map<String, Any>, depth: Int) {
-        map.forEach { (key, value) ->
-            val indent = DEFAULT_INDENT.repeat(depth)
-            if (value is Map<*, *>) {
-                @Suppress("UNCHECKED_CAST")
-                appendKotlinObject(builder, key, value as Map<String, Any>, depth, indent)
-            } else {
-                appendFunctionOrValue(builder, key, value.toString(), indent)
+    private fun TypeSpec.Builder.addObjectContent(root: Map<String, Any>): TypeSpec.Builder {
+        @Suppress("UNCHECKED_CAST") // presuming the structure of the map
+        root.forEach { (key, value) ->
+            when (value) {
+                is Map<*, *> -> addObject(key, value as Map<String, Any>)
+                else -> addFunctionOrProperty(key, value.toString())
             }
         }
+        return this
     }
 
-    private fun appendKotlinObject(
-        builder: StringBuilder,
-        key: String,
-        value: Map<String, Any>,
-        depth: Int,
-        indent: String,
-    ) {
-        builder.apply {
-            append("${indent}public object $key {\n")
-            generateKotlinCode(this, value, depth + 1)
-            append("$indent}\n")
-        }
+    private fun TypeSpec.Builder.addObject(key: String, value: Map<String, Any>) {
+        addType(
+            TypeSpec.objectBuilder(key)
+                .addObjectContent(value)
+                .build(),
+        )
     }
 
-    private fun appendFunctionOrValue(
-        builder: StringBuilder,
-        key: String,
-        value: String,
-        indent: String,
-    ) {
+    private fun TypeSpec.Builder.addFunctionOrProperty(key: String, value: String) {
         val translation = fileContent.filter { it.key == value }.toString()
         val dataTypes = determineDataTypes(translation)
 
         if (dataTypes.isNotEmpty()) {
-            appendFunctionDeclaration(builder, key, value, dataTypes, indent)
-        } else {
-            val validName = returnValidValName(key)
-            builder.append("${indent}public val $validName: String = localise(\"$value\")\n")
-        }
-    }
-
-    private fun returnValidValName(key: String): String {
-        if (key == "continue") {
-            return "`continue`"
-        } else return key
-    }
-
-    private fun appendFunctionDeclaration(
-        builder: StringBuilder,
-        key: String,
-        value: String,
-        dataTypes: List<String>,
-        indent: String,
-    ) {
-        builder.apply {
-            append("${indent}public fun $key(")
-            dataTypes.forEachIndexed { index, type ->
-                if (index > 0) append(", ")
-                append("param$index: $type")
+            val parameters = dataTypes.mapIndexed { index, type ->
+                ParameterSpec.builder("param${index + 1}", type)
+                    .build()
             }
-            append("): String {\n")
-            append("${indent}${DEFAULT_INDENT}return localise(\"$value\", ")
-            append(dataTypes.indices.joinToString { "param$it" })
-            append(")\n$indent}\n")
+            val parametersCall = parameters.joinToString { it.name }
+            addFunction(
+                FunSpec.builder(key)
+                    .addParameters(parameters)
+                    .returns(String::class)
+                    .addStatement("""return localise("$value", $parametersCall)""")
+                    .build(),
+            )
+        } else {
+            addProperty(
+                PropertySpec.builder(key, String::class)
+                    .initializer("""localise("$value")""")
+                    .build(),
+            )
         }
     }
 
     // %s - valid parameter, can be without $
-    private fun determineDataTypes(formatString: String): List<String> {
+    private fun determineDataTypes(formatString: String): List<KClass<*>> {
         val formatSpecifiers = FORMAT_SPECIFIER_REGEX.findAll(formatString)
         return formatSpecifiers.map { determineDataType(it.value) }.toList()
     }
 
-    private fun determineDataType(formatSpecifier: String): String {
+    private fun determineDataType(formatSpecifier: String): KClass<*> {
         return when {
-            formatSpecifier.contains("\$s") -> "String"
-            formatSpecifier.contains("\$d") -> "Int"
-            formatSpecifier.contains("\$f") -> "Float"
-            formatSpecifier.contains("s") -> "String"
-            formatSpecifier.contains("d") -> "Int"
-            formatSpecifier.contains("f") -> "Float"
-            else -> "Any"
+            formatSpecifier.contains("\$s") -> String::class
+            formatSpecifier.contains("\$d") -> Int::class
+            formatSpecifier.contains("\$f") -> Float::class
+            formatSpecifier.contains("s") -> String::class
+            formatSpecifier.contains("d") -> Int::class
+            formatSpecifier.contains("f") -> Float::class
+            else -> Any::class
         }
     }
 }

--- a/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/FileWriter.kt
+++ b/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/FileWriter.kt
@@ -3,11 +3,11 @@ package com.qinshift.linguine.linguinegenerator
 import java.io.File
 
 class FileWriter {
-    fun writeToFile(outputFile: File, outputFileContent: StringBuilder) {
+    fun writeToFile(outputFile: File, outputFileContent: String) {
         if (!outputFile.exists()) {
             outputFile.parentFile?.mkdirs()
             outputFile.createNewFile()
         }
-        outputFile.writeText(outputFileContent.toString())
+        outputFile.writeText(outputFileContent)
     }
 }

--- a/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/LinguinePlugin.kt
+++ b/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/LinguinePlugin.kt
@@ -128,7 +128,7 @@ abstract class GenerateStringsTask : DefaultTask() {
 
         // Generate content for the Kotlin Localization File
         val fileContentGenerator = FileContentGenerator(fileContent)
-        val outputFileContent = fileContentGenerator.generateFileContent(root = root)
+        val outputFileContent = fileContentGenerator.generateFileContent(root)
 
         // Write built kotlin class and its nested structure into Kotlin File
         val fileWriter = FileWriter()
@@ -138,7 +138,7 @@ abstract class GenerateStringsTask : DefaultTask() {
         )
         logger.lifecycle(
             "Linguine: File ${outputFile.asFile.get().name} " +
-                "has been successfully created in the directory ${outputFile.asFile.get().path}"
+                "has been successfully created in the directory ${outputFile.asFile.get().path}",
         )
     }
 }


### PR DESCRIPTION
We have less control over the formatting and it is arguably uglier. There are also some unnecessary imports of basic types that are automatically added when the types are used as function parameters. I wasn't able to prevent this.

The plus side is that building the code is done largely declaratively and we can be sure the result **can be built**.

There is one small change - the parameters are **indexed from 1**.