### PR TITLE
Build workflow now runs on Linux runner (without iOS build)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Build workflow now runs on Linux runner (without iOS build) to save CI time. MaxOS runners cost 10x more than Linux and the Kotlin native build takes 10x time to finish.