### PR TITLE
Draft: Fix: FileParser file name generation + package name generation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ subprojects {
     apply<MavenPublishPlugin>()
 
     group = "com.qinshift.linguine"
-    version = System.getenv("NEXT_VERSION") ?: "0.3.0"
+    version = System.getenv("NEXT_VERSION") ?: "0.3.1"
 
     mavenPublishing {
         publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)

--- a/linguine-generator/src/functionalTest/kotlin/com/qinshift/linguine/linguinegenerator/FileContentGeneratorTest.kt
+++ b/linguine-generator/src/functionalTest/kotlin/com/qinshift/linguine/linguinegenerator/FileContentGeneratorTest.kt
@@ -10,6 +10,7 @@ class FileContentGeneratorTest {
 
     @Test
     fun `generateFileContent with overlapping key names produces differentiated Kotlin object structures`() {
+        val sourceRoot = Path("src/main/kotlin")
         val outputDirectory = Path("src/main/kotlin/com/example/app/")
         val fileContent: Map<String, String> = mapOf(
             "settings__privacy__title" to "Title for Privacy Settings",
@@ -24,7 +25,7 @@ class FileContentGeneratorTest {
             "privacy" to ("settings__privacy" to "Privacy Settings"),
             "title" to ("settings__title" to "Title for Settings"),
         )
-        val generator = FileContentGenerator(outputDirectory, fileContent)
+        val generator = FileContentGenerator(sourceRoot, outputDirectory, fileContent)
 
         val result = generator.generateFileContent(
             outputDirectory.resolve("SettingsStrings.kt"),
@@ -33,7 +34,7 @@ class FileContentGeneratorTest {
         )
 
         val expected = """
-            package presentation
+            package com.example.app
 
             import com.qinshift.linguine.linguineruntime.presentation.Localiser.localise
             import kotlin.String
@@ -53,6 +54,7 @@ class FileContentGeneratorTest {
 
     @Test
     fun `generateFileContent with empty values produces valid Kotlin object structures`() {
+        val sourceRoot = Path("src/main/kotlin")
         val outputDirectory = Path("src/main/kotlin/com/example/app/")
         val fileContent: Map<String, String> = mapOf(
             "section__empty_value" to "",
@@ -61,7 +63,7 @@ class FileContentGeneratorTest {
         val root: Map<String, Any> = mapOf(
             "emptyValue" to ("section__empty_value" to ""),
         )
-        val generator = FileContentGenerator(outputDirectory, fileContent)
+        val generator = FileContentGenerator(sourceRoot, outputDirectory, fileContent)
 
         val result = generator.generateFileContent(
             outputDirectory.resolve("SectionStrings.kt"),
@@ -70,7 +72,7 @@ class FileContentGeneratorTest {
         )
 
         val expected = """
-        package presentation
+        package com.example.app
 
         import com.qinshift.linguine.linguineruntime.presentation.Localiser.localise
         import kotlin.String
@@ -84,6 +86,7 @@ class FileContentGeneratorTest {
 
     @Test
     fun `generateFileContent with deeply nested structures produces expected Kotlin object structure`() {
+        val sourceRoot = Path("src/main/kotlin")
         val outputDirectory = Path("src/main/kotlin/com/example/app/")
         val fileContent: Map<String, String> = mapOf(
             "deep__level_one__level_two__level_three__final" to "Deeply Nested Value",
@@ -98,13 +101,13 @@ class FileContentGeneratorTest {
                 ),
             ),
         )
-        val generator = FileContentGenerator(outputDirectory, fileContent)
+        val generator = FileContentGenerator(sourceRoot, outputDirectory, fileContent)
 
         val result =
             generator.generateFileContent(outputDirectory.resolve("DeepStrings.kt"), "Deep", root)
 
         val expected = """
-        package presentation
+        package com.example.app
 
         import com.qinshift.linguine.linguineruntime.presentation.Localiser.localise
         import kotlin.String
@@ -125,6 +128,7 @@ class FileContentGeneratorTest {
 
     @Test
     fun `generateFileContent with simple values produces expected Kotlin properties`() {
+        val sourceRoot = Path("src/main/kotlin")
         val outputDirectory = Path("src/main/kotlin/com/example/app/")
         val fileContent: Map<String, String> = mapOf(
             "simple__key" to "Simple Value",
@@ -135,13 +139,13 @@ class FileContentGeneratorTest {
             "Simple" to ("simple__key" to "Simple Value"),
             "AnotherSimple" to ("another__simple__key" to "Another Simple Value"),
         )
-        val generator = FileContentGenerator(outputDirectory, fileContent)
+        val generator = FileContentGenerator(sourceRoot, outputDirectory, fileContent)
 
         val result =
             generator.generateFileContent(outputDirectory.resolve("Strings.kt"), "Strings", root)
 
         val expected = """
-        package presentation
+        package com.example.app
 
         import com.qinshift.linguine.linguineruntime.presentation.Localiser.localise
         import kotlin.String
@@ -157,6 +161,7 @@ class FileContentGeneratorTest {
 
     @Test
     fun `generateFileContent with complex function parameterization generates correct function signatures`() {
+        val sourceRoot = Path("src/main/kotlin")
         val outputDirectory = Path("src/main/kotlin/com/example/app/")
         val fileContent: Map<String, String> = mapOf(
             "error__message__with_parameters" to "Error %1\$s occurred at %2\$d:%3\$d on %4\$s",
@@ -168,13 +173,13 @@ class FileContentGeneratorTest {
                     "Error %1\$s occurred at %2\$d:%3\$d on %4\$s"),
             ),
         )
-        val generator = FileContentGenerator(outputDirectory, fileContent)
+        val generator = FileContentGenerator(sourceRoot, outputDirectory, fileContent)
 
         val result =
             generator.generateFileContent(outputDirectory.resolve("Strings.kt"), "Strings", root)
 
         val expected = """
-        package presentation
+        package com.example.app
 
         import com.qinshift.linguine.linguineruntime.presentation.Localiser.localise
         import kotlin.Int
@@ -196,6 +201,7 @@ class FileContentGeneratorTest {
 
     @Test
     fun `generateFileContent with special characters in keys produces expected Kotlin object structure`() {
+        val sourceRoot = Path("src/main/kotlin")
         val outputDirectory = Path("src/main/kotlin/com/example/app/")
         val fileContent: Map<String, String> = mapOf(
             "special__char@cters__key!__value" to "Special Value",
@@ -214,13 +220,13 @@ class FileContentGeneratorTest {
                 ),
             ),
         )
-        val generator = FileContentGenerator(outputDirectory, fileContent)
+        val generator = FileContentGenerator(sourceRoot, outputDirectory, fileContent)
 
         val result =
             generator.generateFileContent(outputDirectory.resolve("Strings.kt"), "Strings", root)
 
         val expected = """
-        package presentation
+        package com.example.app
 
         import com.qinshift.linguine.linguineruntime.presentation.Localiser.localise
         import kotlin.String
@@ -246,6 +252,7 @@ class FileContentGeneratorTest {
     @Suppress("LongMethod")
     @Test
     fun `generateFileContent with simple map produces expected Kotlin object structure`() {
+        val sourceRoot = Path("src/main/kotlin")
         val outputDirectory = Path("src/main/kotlin/com/example/app/")
         val fileContent: Map<String, String> = mapOf(
             "activation__forgotten_password__birthdate__cancel_button" to "Cancel",
@@ -289,13 +296,13 @@ class FileContentGeneratorTest {
                 ),
             ),
         )
-        val generator = FileContentGenerator(outputDirectory, fileContent)
+        val generator = FileContentGenerator(sourceRoot, outputDirectory, fileContent)
 
         val result =
             generator.generateFileContent(outputDirectory.resolve("Strings.kt"), "Strings", root)
 
         val expected = """
-        package presentation
+        package com.example.app
 
         import com.qinshift.linguine.linguineruntime.presentation.Localiser.localise
         import kotlin.String
@@ -346,6 +353,7 @@ class FileContentGeneratorTest {
 
     @Test
     fun `generateFileContent with function parameters generates kotlin object with function parameters`() {
+        val sourceRoot = Path("src/main/kotlin")
         val outputDirectory = Path("src/main/kotlin/com/example/app/")
         val fileContent: Map<String, String> = mapOf(
             "activation__forgotten_password__birthdate__cancel_button" to "\"%s %d %f %${'$'}s %${'$'}d %${'$'}f\"",
@@ -361,13 +369,13 @@ class FileContentGeneratorTest {
                 ),
             ),
         )
-        val generator = FileContentGenerator(outputDirectory, fileContent)
+        val generator = FileContentGenerator(sourceRoot, outputDirectory, fileContent)
 
         val result =
             generator.generateFileContent(outputDirectory.resolve("Strings.kt"), "Strings", root)
 
         val expected = """
-            package presentation
+            package com.example.app
             
             import com.qinshift.linguine.linguineruntime.presentation.Localiser.localise
             import kotlin.Float

--- a/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/FileParser.kt
+++ b/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/FileParser.kt
@@ -68,6 +68,7 @@ class FileParser(
         }
     }
 
-    private fun String.toPascalCase(splitBy: String): String =
-        this.split(splitBy).joinToString("") { it.replaceFirstChar { c -> c.uppercaseChar() } }
+    private fun String.toPascalCase(delimiter: String): String {
+        return split(delimiter).joinToString("") { word -> word.replaceFirstChar(Char::uppercaseChar) }
+    }
 }

--- a/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/FileParser.kt
+++ b/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/FileParser.kt
@@ -8,11 +8,20 @@ class FileParser(
     fun generateGroupedMapStructure(): Map<String, Map<String, Any>> {
         val groupedMap = mutableMapOf<String, MutableMap<String, Pair<String, String>>>()
         fileContent.forEach { (key, value) ->
-            val firstSegment =
-                key.substringBefore(majorDelimiter).replaceFirstChar { it.uppercaseChar() }
-            val restOfKey = key.substringAfter(majorDelimiter)
-            groupedMap.computeIfAbsent(firstSegment) { mutableMapOf() }[restOfKey] = key to value
+            val groupName: String
+            val nestedKey: String
+
+            if (key.contains(majorDelimiter)) {
+                groupName = key.substringBefore(majorDelimiter).toPascalCase(minorDelimiter)
+                nestedKey = key.substringAfter(majorDelimiter)
+            } else {
+                groupName = key.toPascalCase(minorDelimiter)
+                nestedKey = key
+            }
+
+            groupedMap.computeIfAbsent(groupName) { mutableMapOf() }[nestedKey] = key to value
         }
+
         return groupedMap.mapValues { (_, map) -> generateNestedMapStructure(map) }
     }
 
@@ -51,11 +60,14 @@ class FileParser(
         }
     }
 
-    private fun formatPart(part: String, isLast: Boolean): String {
-        return if (isLast) {
+    private fun formatPart(part: String, isIntermediate: Boolean): String {
+        return if (isIntermediate) {
             part.replaceFirstChar { it.uppercaseChar() }
         } else {
             part.replaceFirstChar { it.lowercase() }
         }
     }
+
+    private fun String.toPascalCase(splitBy: String): String =
+        this.split(splitBy).joinToString("") { it.replaceFirstChar { c -> c.uppercaseChar() } }
 }

--- a/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/LinguineConfig.kt
+++ b/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/LinguineConfig.kt
@@ -6,6 +6,7 @@ open class LinguineConfig {
     var inputFilePath: String = ""
     var inputFileType: FileType = FileType.JSON
     var outputFilePath: String = ""
+    var sourceRootPath: String = ""
     var majorDelimiter: String = "__"
     var minorDelimiter: String = "_"
     var buildTaskName: String? = null


### PR DESCRIPTION
- "two_factor_authentication__message" generated as Two_factor_authentication
- newly "two_factor_authentication__message" should generate a file with name TwoFactorAuthentication