### PR TITLE
Fix: Gradle Task Isolation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ subprojects {
     apply<MavenPublishPlugin>()
 
     group = "com.qinshift.linguine"
-    version = System.getenv("NEXT_VERSION") ?: "0.3.1"
+    version = System.getenv("NEXT_VERSION") ?: "0.4.1"
 
     mavenPublishing {
         publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)


### PR DESCRIPTION
Fix: Ensure task isolation and improve Gradle configuration cache compatibility

- Remove runtime access to project extensions and layout from GenerateStringsTask
- Inject ProjectLayout into GenerateStringsTask constructor
- Move sourceRootPath and outputFilePath to task Input properties
- Refactor plugin apply logic to configure task inputs at registration time
- Simplify dependency setup in configureForKmp/configureForAndroid/configureForJvm
- Ensure generateStrings task runs before compile tasks via afterEvaluate