### PR TITLE
Feature: Configurable output suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,20 @@
 
 ## ✨ Features
 
-- **JSON Localization Support:**  
-  Converts nested JSON localization files into Kotlin `object` structures with type-safe string accessors.
+- **JSON Localization Support**  
+  Converts JSON localization files into Kotlin `object` structures with type-safe string accessors using configurable delimiters.
 
-- **Automatic Package Naming:**  
+- **Automatic Package Naming**  
   Builds the Kotlin package name from the **generated file’s location relative to `sourceRootPath`**, keeping your codebase organized.
 
-- **Incremental Build Support:**  
+- **Configurable Naming**  
+  Customize key delimiters and the suffix used for generated file and object names via `outputSuffix` (e.g. `Strings`, `L10n`).
+
+- **Incremental Build Support**  
   Processes only changed files, speeding up builds.
 
-- **Multiplatform Compatible:**  
+- **Multiplatform Compatible**  
   Works with Kotlin Multiplatform, Android, and JVM projects.
-
-- **Highly Configurable:**  
-  Customize input/output paths, delimiters, and task names.
 
 ---
 
@@ -37,13 +37,14 @@ plugins {
 
 ## ⚙️ Configuration
 
-### Example:
+### Example
 
 ```kotlin
 linguine {
     inputFilePath = "localization-data/en/strings.json"
     outputFilePath = "src/commonMain/kotlin/com/example/app/localisation/en"
     sourceRootPath = "src/commonMain/kotlin"
+    outputSuffix = "Strings"
     majorDelimiter = "__"
     minorDelimiter = "_"
 }
@@ -51,15 +52,16 @@ linguine {
 
 ### 🔑 Key Configuration Options
 
-| Property          | Description                                                                                 |
-|-------------------|---------------------------------------------------------------------------------------------|
-| `inputFilePath`   | Path to the input JSON file with localizations. Independent from the output structure.     |
-| `inputFileType`   | (Optional) Type of the input file (default: `FileType.JSON`).                                          |
-| `outputFilePath`  | Where to place the generated Kotlin file(s). Defines the target folder in your source tree. |
-| `sourceRootPath`  | (Optional) **Base folder for generating package names. The package is computed as the path from `sourceRootPath` to `outputFilePath`.** |
-| `majorDelimiter`  | (Optional) Splits keys into nested Kotlin `object`s. (default: `__`)                                    |
-| `minorDelimiter`  | (Optional) Formats individual string names. (default: `_`)                                               |
-| `buildTaskName`   | (Optional) Custom name for the Gradle task. (default: `generateStrings`)                                                 |
+| Property          | Type / Default         | Required | Description |
+|-------------------|------------------------|----------|-------------|
+| `inputFilePath`   | `String` (no default)  | Yes      | Path to the input JSON file with localizations. Independent from the output structure. |
+| `inputFileType`   | `FileType` = `JSON`    | No       | Type of the input file. Currently only JSON is supported. |
+| `outputFilePath`  | `String` (no default)  | Yes      | Directory where generated Kotlin file(s) are written. Defines the target folder in your source tree. |
+| `sourceRootPath`  | `String` (no default)  | No       | Base folder for generating package names. The package is computed as the path from `sourceRootPath` to `outputFilePath`. If omitted or resulting path is blank, `presentation` is used. |
+| `outputSuffix`    | `String` = `"Strings"` | No       | Suffix appended to the generated file and root-level object. For example, group `Home` with `outputSuffix = "Strings"` generates `HomeStrings.kt` and `object HomeStrings`. |
+| `majorDelimiter`  | `String` = `"__"`      | No       | Splits keys into nested Kotlin `object`s. For example, `home__welcome_message` creates a `Home*` group and a `welcomeMessage` member. |
+| `minorDelimiter`  | `String` = `"_"`       | No       | Splits individual key segments into words for camelCase members (e.g. `welcome_message` → `welcomeMessage`). |
+| `buildTaskName`   | `String?` = `null`     | No       | Custom name for a build task that should depend on string generation. If not set, all `compile*` tasks will depend on `generateStrings`. |
 
 ---
 
@@ -78,11 +80,13 @@ linguine {
 ```
 
 ➡️ Package name:
+
 ```kotlin
 package com.example.app.localisation.en
 ```
 
 If the relative path is empty or invalid, it falls back to:
+
 ```kotlin
 package presentation
 ```
@@ -92,43 +96,61 @@ package presentation
 ## 🧪 Usage Example
 
 ### Input JSON (`localization-data/en/strings.json`)
+
 ```json
 {
   "home__welcome_message": "Welcome Home!"
 }
 ```
 
-### Generated Kotlin (`src/commonMain/kotlin/com/example/app/localisation/en/Strings.kt`)
+### Generated Kotlin (`src/commonMain/kotlin/com/example/app/localisation/en/HomeStrings.kt`)
+
+Assuming:
+
+```kotlin
+outputSuffix = "Strings"
+```
+
+Generated file:
+
 ```kotlin
 package com.example.app.localisation.en
 
-object Home {
+import com.qinshift.linguine.linguineruntime.presentation.Localiser.localise
+
+object HomeStrings {
     val welcomeMessage: String = localise("home__welcome_message")
 }
 ```
 
 ### Usage in Code
+
 ```kotlin
-val msg = Home.welcomeMessage
+val msg = HomeStrings.welcomeMessage
 ```
 
 ---
 
 ## 🚀 Build Integration
 
-The plugin runs during the Gradle build:
+The plugin registers a `generateStrings` task and wires it into the build.
+
+Run the full build:
 
 ```bash
 ./gradlew build
 ```
 
-Or, run the task directly (if configured):
+Or, run string generation directly:
+
 ```bash
-./gradlew generateLocalization
+./gradlew generateStrings
 ```
+
+If you set `buildTaskName`, that task will depend on `generateStrings`; otherwise all `compile*` tasks will.
 
 ---
 
 ## 📝 License
 
-See [license.md](license.md)
+See [license.md](license.md).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ subprojects {
     apply<MavenPublishPlugin>()
 
     group = "com.qinshift.linguine"
-    version = System.getenv("NEXT_VERSION") ?: "0.4.1"
+    version = System.getenv("NEXT_VERSION") ?: "0.4.3"
 
     mavenPublishing {
         publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)

--- a/linguine-generator/build.gradle.kts
+++ b/linguine-generator/build.gradle.kts
@@ -20,7 +20,6 @@ buildConfig {
 }
 
 gradlePlugin {
-    // Define the plugin
     val linguine by plugins.creating {
         id = "com.qinshift.linguine"
         implementationClass = "com.qinshift.linguine.linguinegenerator.LinguinePlugin"

--- a/linguine-generator/src/functionalTest/kotlin/com/qinshift/linguine/linguinegenerator/FileContentGeneratorTest.kt
+++ b/linguine-generator/src/functionalTest/kotlin/com/qinshift/linguine/linguinegenerator/FileContentGeneratorTest.kt
@@ -4,6 +4,7 @@ import io.kotest.matchers.shouldBe
 import kotlin.io.path.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 @Suppress("StringLiteralDuplication")
 class FileContentGeneratorTest {
@@ -25,7 +26,12 @@ class FileContentGeneratorTest {
             "privacy" to ("settings__privacy" to "Privacy Settings"),
             "title" to ("settings__title" to "Title for Settings"),
         )
-        val generator = FileContentGenerator(sourceRoot, outputDirectory, fileContent)
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            fileContent = fileContent,
+            outputSuffix = "Strings",
+        )
 
         val result = generator.generateFileContent(
             outputDirectory.resolve("SettingsStrings.kt"),
@@ -63,7 +69,12 @@ class FileContentGeneratorTest {
         val root: Map<String, Any> = mapOf(
             "emptyValue" to ("section__empty_value" to ""),
         )
-        val generator = FileContentGenerator(sourceRoot, outputDirectory, fileContent)
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            fileContent = fileContent,
+            outputSuffix = "Strings",
+        )
 
         val result = generator.generateFileContent(
             outputDirectory.resolve("SectionStrings.kt"),
@@ -101,7 +112,12 @@ class FileContentGeneratorTest {
                 ),
             ),
         )
-        val generator = FileContentGenerator(sourceRoot, outputDirectory, fileContent)
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            fileContent = fileContent,
+            outputSuffix = "Strings",
+        )
 
         val result =
             generator.generateFileContent(outputDirectory.resolve("DeepStrings.kt"), "Deep", root)
@@ -139,7 +155,12 @@ class FileContentGeneratorTest {
             "Simple" to ("simple__key" to "Simple Value"),
             "AnotherSimple" to ("another__simple__key" to "Another Simple Value"),
         )
-        val generator = FileContentGenerator(sourceRoot, outputDirectory, fileContent)
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            fileContent = fileContent,
+            outputSuffix = "Strings",
+        )
 
         val result =
             generator.generateFileContent(outputDirectory.resolve("Strings.kt"), "Strings", root)
@@ -173,7 +194,12 @@ class FileContentGeneratorTest {
                     "Error %1\$s occurred at %2\$d:%3\$d on %4\$s"),
             ),
         )
-        val generator = FileContentGenerator(sourceRoot, outputDirectory, fileContent)
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            fileContent = fileContent,
+            outputSuffix = "Strings",
+        )
 
         val result =
             generator.generateFileContent(outputDirectory.resolve("Strings.kt"), "Strings", root)
@@ -220,7 +246,12 @@ class FileContentGeneratorTest {
                 ),
             ),
         )
-        val generator = FileContentGenerator(sourceRoot, outputDirectory, fileContent)
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            fileContent = fileContent,
+            outputSuffix = "Strings",
+        )
 
         val result =
             generator.generateFileContent(outputDirectory.resolve("Strings.kt"), "Strings", root)
@@ -296,7 +327,12 @@ class FileContentGeneratorTest {
                 ),
             ),
         )
-        val generator = FileContentGenerator(sourceRoot, outputDirectory, fileContent)
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            fileContent = fileContent,
+            outputSuffix = "Strings",
+        )
 
         val result =
             generator.generateFileContent(outputDirectory.resolve("Strings.kt"), "Strings", root)
@@ -369,7 +405,12 @@ class FileContentGeneratorTest {
                 ),
             ),
         )
-        val generator = FileContentGenerator(sourceRoot, outputDirectory, fileContent)
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            fileContent = fileContent,
+            outputSuffix = "Strings",
+        )
 
         val result =
             generator.generateFileContent(outputDirectory.resolve("Strings.kt"), "Strings", root)
@@ -401,5 +442,142 @@ class FileContentGeneratorTest {
             }
         """
         result.trimIndent() shouldBe expected.trimIndent()
+    }
+
+    @Test
+    fun `generateFileContents uses outputSuffix in file name and root object name`() {
+        val sourceRoot = Path("src/main/kotlin")
+        val outputDirectory = Path("src/main/kotlin/com/example/app/")
+        val fileContent: Map<String, String> = mapOf(
+            "home__title" to "Home Title",
+        )
+
+        val groupedMap: Map<String, Map<String, Any>> = mapOf(
+            "Home" to mapOf(
+                "title" to ("home__title" to "Home Title"),
+            ),
+        )
+
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            fileContent = fileContent,
+            outputSuffix = "L10n",
+        )
+
+        val result = generator.generateFileContents(groupedMap)
+
+        result.size shouldBe 1
+
+        val (path, content) = result.entries.single()
+
+        path shouldBe outputDirectory.resolve("HomeL10n.kt")
+
+        assertTrue(
+            content.contains("public object HomeL10n"),
+            "Expected root object 'HomeL10n' in generated content, but was:\n$content",
+        )
+
+        assertTrue(
+            content.contains("""public val title: String = localise("home__title")"""),
+            "Expected property for 'home__title' in generated content, but was:\n$content",
+        )
+    }
+
+    @Test
+    fun `generateFileContents capitalizes lowercase group name and applies suffix`() {
+        val sourceRoot = Path("src/main/kotlin")
+        val outputDirectory = Path("src/main/kotlin/com/example/app/")
+        val fileContent: Map<String, String> = mapOf(
+            "home__title" to "Home Title",
+        )
+
+        val groupedMap: Map<String, Map<String, Any>> = mapOf(
+            "home" to mapOf(
+                "title" to ("home__title" to "Home Title"),
+            ),
+        )
+
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            fileContent = fileContent,
+            outputSuffix = "L10n",
+        )
+
+        val result = generator.generateFileContents(groupedMap)
+
+        result.size shouldBe 1
+
+        val (path, content) = result.entries.single()
+
+        path shouldBe outputDirectory.resolve("HomeL10n.kt")
+
+        assertTrue(
+            content.contains("public object HomeL10n"),
+            "Expected root object 'HomeL10n' in generated content, but was:\n$content",
+        )
+
+        assertTrue(
+            content.contains("""public val title: String = localise("home__title")"""),
+            "Expected property for 'home__title' in generated content, but was:\n$content",
+        )
+    }
+
+    @Test
+    fun `generateFileContent falls back to presentation package when relative path is blank`() {
+        val sourceRoot = Path("src/main/kotlin/com/example/app")
+        val outputDirectory = Path("src/main/kotlin/com/example/app")
+        val fileContent: Map<String, String> = mapOf(
+            "key" to "Value",
+        )
+
+        val root: Map<String, Any> = mapOf(
+            "key" to ("key" to "Value"),
+        )
+
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            fileContent = fileContent,
+            outputSuffix = "Strings",
+        )
+
+        val result = generator.generateFileContent(
+            outputDirectory.resolve("Strings.kt"),
+            "Strings",
+            root,
+        )
+
+        assertTrue(
+            result.trimStart().startsWith("package presentation"),
+            "Expected fallback package 'presentation' but was:\n$result",
+        )
+    }
+
+    @Test
+    fun `generateFileContent falls back to property when translation key is missing`() {
+        val sourceRoot = Path("src/main/kotlin")
+        val outputDirectory = Path("src/main/kotlin/com/example/app/")
+        val fileContent: Map<String, String> = emptyMap()
+
+        val root: Map<String, Any> = mapOf(
+            "title" to ("missing_key" to "This value is ignored by generator"),
+        )
+
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            fileContent = fileContent,
+            outputSuffix = "Strings",
+        )
+
+        val result =
+            generator.generateFileContent(outputDirectory.resolve("Strings.kt"), "Strings", root)
+
+        assertTrue(
+            result.contains("""public val title: String = localise("missing_key")"""),
+            "Expected fallback property for missing key in generated content, but was:\n$result",
+        )
     }
 }

--- a/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/FileContentGenerator.kt
+++ b/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/FileContentGenerator.kt
@@ -14,6 +14,7 @@ class FileContentGenerator(
     private val sourceRoot: Path,
     private val outputDirectory: Path,
     private val fileContent: Map<String, String>,
+    private val outputSuffix: String,
 ) {
 
     fun generateFileContents(groupedMap: Map<String, Map<String, Any>>): Map<Path, String> {
@@ -21,8 +22,11 @@ class FileContentGenerator(
             val capitalizedFileName = fileName.replaceFirstChar {
                 if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
             }
-            val filePath = outputDirectory.resolve("${capitalizedFileName}Strings.kt")
-            filePath to generateFileContent(filePath, capitalizedFileName, content)
+
+            val rootObjectName = "$capitalizedFileName$outputSuffix"
+            val filePath = outputDirectory.resolve("$rootObjectName.kt")
+
+            filePath to generateFileContent(filePath, rootObjectName, content)
         }.toMap()
     }
 

--- a/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/Linguine.kt
+++ b/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/Linguine.kt
@@ -7,6 +7,7 @@ open class Linguine {
     var inputFileType: FileType = FileType.JSON
     var outputFilePath: String = ""
     var sourceRootPath: String = ""
+    var outputSuffix: String = "Strings"
     var majorDelimiter: String = "__"
     var minorDelimiter: String = "_"
     var buildTaskName: String? = null

--- a/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/LinguinePlugin.kt
+++ b/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/LinguinePlugin.kt
@@ -47,6 +47,7 @@ class LinguinePlugin : Plugin<Project> {
             outputDirectory.set(project.layout.projectDirectory.dir(extension.outputFilePath))
             sourceRootPath.set(extension.sourceRootPath)
             outputFilePath.set(extension.outputFilePath)
+            outputSuffix.set(extension.outputSuffix)
         }
 
         project.afterEvaluate {
@@ -115,6 +116,9 @@ abstract class GenerateStringsTask @Inject constructor(
     @get:Input
     abstract val outputFilePath: GradleProperty<String>
 
+    @get:Input
+    abstract val outputSuffix: GradleProperty<String>
+
     @TaskAction
     fun generate() {
         // Read input file
@@ -151,6 +155,7 @@ abstract class GenerateStringsTask @Inject constructor(
             sourceRoot = resolvedSourceRoot,
             outputDirectory = resolvedOutputPath,
             fileContent = fileContent,
+            outputSuffix = outputSuffix.get()
         )
 
         val outputFileContent = fileContentGenerator.generateFileContents(groupedMap)

--- a/linguine-generator/src/test/kotlin/com/qinshift/linguine/linguinegenerator/LinguinePluginTest.kt
+++ b/linguine-generator/src/test/kotlin/com/qinshift/linguine/linguinegenerator/LinguinePluginTest.kt
@@ -10,14 +10,12 @@ class LinguinePluginTest {
 
     @Test
     fun `plugin registers a task`() {
-        // Create a test project and apply the plugin
         val project: Project = ProjectBuilder.builder().build()
         project.plugins.apply("com.qinshift.linguine")
         val extension = project.extensions.getByType(Linguine::class.java)
         extension.inputFilePath = "src/commonMain/resources/string.json"
         extension.outputFilePath = "presentation"
 
-        // Verify the result
         assertNotNull(project.tasks.findByName("generateStrings"))
     }
 


### PR DESCRIPTION
### Summary
Adds a new `outputSuffix` option to the Linguine Gradle plugin, allowing customization of the suffix used for generated Kotlin filenames and root objects.

### Changes
- Added `outputSuffix` to the `Linguine` extension and `GenerateStringsTask`
- Passed the suffix into `FileContentGenerator`
- Updated file/object naming to use the configured suffix instead of the hardcoded "Strings"

### Result
Users can now configure:

```kotlin
linguine {
    outputSuffix = "L10n"
}
```

This produces:

- HomeL10n.kt
- object HomeL10n

### Notes
Backwards compatible — default suffix remains "Strings".
