### PR TITLE
feature: add support for plural localizations and `vararg Any` format…

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ plugins {
 ### Example
 
 ```kotlin
+import com.qinshift.linguine.linguinegenerator.PluralFormPolicy
+
 linguine {
     inputFilePath = "localization-data/en/strings.json"
     outputFilePath = "src/commonMain/kotlin/com/example/app/localisation/en"
@@ -47,6 +49,7 @@ linguine {
     outputSuffix = "Strings"
     majorDelimiter = "__"
     minorDelimiter = "_"
+    pluralFormPolicy = PluralFormPolicy.REQUIRE_ALL_FORMS
 }
 ```
 
@@ -62,6 +65,7 @@ linguine {
 | `majorDelimiter`  | `String` = `"__"`      | No       | Splits keys into nested Kotlin `object`s. For example, `home__welcome_message` creates a `Home*` group and a `welcomeMessage` member. |
 | `minorDelimiter`  | `String` = `"_"`       | No       | Splits individual key segments into words for camelCase members (e.g. `welcome_message` → `welcomeMessage`). |
 | `buildTaskName`   | `String?` = `null`     | No       | Custom name for a build task that should depend on string generation. If not set, all `compile*` tasks will depend on `generateStrings`. |
+| `pluralFormPolicy` | `PluralFormPolicy` = `REQUIRE_ALL_FORMS` | No | Controls generator-side plural validation. Use `REQUIRE_ALL_FORMS` for providers that require `zero`, `one`, `two`, `few`, `many`, and `other`; use `REQUIRE_OTHER_ONLY` when only `other` must be present. |
 
 ---
 
@@ -128,6 +132,220 @@ object HomeStrings {
 ```kotlin
 val msg = HomeStrings.welcomeMessage
 ```
+
+### Plural Example
+
+Input JSON:
+
+```json
+{
+  "catalog__item_count": {
+    "zero": "%1$s no items",
+    "one": "%1$s item",
+    "two": "%1$s items-two",
+    "few": "%1$s items-few",
+    "many": "%1$s items-many",
+    "other": "%1$s items for %2$s"
+  }
+}
+```
+
+Generated Kotlin:
+
+```kotlin
+object CatalogStrings {
+    fun itemCount(count: Number, param1: String, param2: String): String =
+        localisePlural("catalog__item_count", count, param1, param2)
+}
+```
+
+Usage:
+
+```kotlin
+val label = CatalogStrings.itemCount(3, "3", "Warehouse")
+```
+
+The runtime only requires `other` as a fallback plural form. Generator validation is controlled by `pluralFormPolicy`; the default `REQUIRE_ALL_FORMS` keeps strict validation for providers that need every form to be present.
+
+The `count` argument is used only to select the plural form. If the selected text must display the count, pass that value explicitly as a regular placeholder argument, as shown with `param1` above.
+
+If a plural value has no format placeholders, the generated function contains only `count`:
+
+```kotlin
+fun itemCount(count: Number): String
+```
+
+### Placeholder Indexing
+
+Generated function parameters are derived from format placeholders.
+
+Supported placeholder markers are `%s`, `%d`, `%f` and their indexed variants such as `%1$s`, `%2$d`, `%3$f`. These markers are used to detect argument positions. All generated placeholder parameters are typed as `String`; `count` remains the only generated `Number` parameter.
+
+A single placeholder may be left unindexed:
+
+```json
+{
+  "sample__label": "Hello %s"
+}
+```
+
+This generates one parameter:
+
+```kotlin
+fun label(param1: String): String
+```
+
+If a string contains more than one placeholder, every placeholder must be indexed:
+
+```json
+{
+  "sample__label": "%1$s and %2$s"
+}
+```
+
+Generated accessor parameters are based on the complete placeholder index set. For plain text, that set comes from the text value itself. For plural text, that set is collected across all plural forms, so an individual form may use only a subset such as `%1$s` and `%3$s` as long as another form contributes `%2$s`.
+
+The complete generated parameter set must be sequential from `1`. Translations may reorder indexed placeholders, for example `%2$s after %1$s`, but the final combined set must not skip an index.
+
+Unindexed placeholders in multi-placeholder strings are rejected during generation:
+
+```json
+{
+  "sample__label": "%1$s and %s"
+}
+```
+
+Skipped placeholder indexes are also rejected during generation:
+
+```json
+{
+  "sample__label": "%1$s and %3$s"
+}
+```
+
+For plural values, skipped indexes are checked against all forms together. This is valid because `%2$s` exists in another form:
+
+```json
+{
+  "catalog__item_count": {
+    "zero": "%1$s no items",
+    "one": "%1$s item",
+    "two": "%1$s items",
+    "few": "%1$s items for %2$s",
+    "many": "%1$s items",
+    "other": "%1$s items for %2$s"
+  }
+}
+```
+
+### Plural Count Behavior
+
+Plural selection is based on `count: Number`.
+
+The count must be finite. `NaN`, positive infinity, and negative infinity are rejected.
+
+Negative values are supported and are matched by absolute value. For example, `-1` follows the same plural form as `1`.
+
+### REQUIRE_ALL_FORMS Gettext Equations
+
+Linguine plural forms are based on Unicode CLDR plural forms:
+
+```text
+zero, one, two, few, many, other
+```
+
+When `PluralFormPolicy.REQUIRE_ALL_FORMS` is used, the source provider must define all six forms. This keeps the provider export, generator validation, and runtime plural resolution aligned. It also means that provider-side gettext equations must explicitly cover forms such as `two`, even for languages where that form falls back to another grammatical form at runtime.
+
+When configuring `PluralFormPolicy.REQUIRE_ALL_FORMS` in a provider that asks for a `Gettext-style equation for "n"`, use the same form order as Linguine's strict policy:
+
+```text
+0 = zero
+1 = one
+2 = two
+3 = few
+4 = many
+5 = other
+```
+
+The matching equations are:
+
+```text
+English:
+(n == 0) ? 0 : (n == 1) ? 1 : (n == 2) ? 2 : 5
+```
+
+```text
+Czech:
+(n == 0) ? 0 : (n%1 != 0) ? 4 : (n == 1) ? 1 : (n == 2) ? 2 : (n >= 3 && n <= 4) ? 3 : 5
+```
+
+```text
+Slovak:
+(n == 0) ? 0 : (n%1 != 0) ? 4 : (n == 1) ? 1 : (n == 2) ? 2 : (n >= 3 && n <= 4) ? 3 : 5
+```
+
+```text
+French:
+(n == 0) ? 0 : (n >= 0 && n < 2) ? 1 : (n == 2) ? 2 : (n%1 == 0 && n != 0 && n%1000000 == 0) ? 4 : 5
+```
+
+```text
+Spanish:
+(n == 0) ? 0 : (n == 1) ? 1 : (n == 2) ? 2 : (n%1 == 0 && n != 0 && n%1000000 == 0) ? 4 : 5
+```
+
+These formulas follow Linguine's runtime behavior. The `zero` form is treated as an explicit override for `0`; if it is not present at runtime, Linguine falls back to the next selected form when one exists, and then to `other`.
+
+## Runtime Fallback Language
+
+Plural selection in the runtime depends on the language of the loaded localisation file. Because of that, the `strings.json` fallback file must also have an explicit language context.
+
+Linguine calls that language the `default localization language`.
+
+By default, the default localization language is English:
+
+```kotlin
+import com.qinshift.linguine.linguineruntime.presentation.Localiser
+
+Localiser.configureDefaultLocalization("en")
+```
+
+If your `strings.json` file is not English, configure it explicitly during app startup:
+
+```kotlin
+import com.qinshift.linguine.linguineruntime.presentation.Localiser
+
+Localiser.configureDefaultLocalization("cs")
+```
+
+This makes `strings.json` use the correct plural rules for the configured default localization language.
+
+Supported default localization languages are defined in [LanguagePluralSupported.kt](linguine-runtime/src/commonMain/kotlin/com/qinshift/linguine/linguineruntime/presentation/LanguagePluralSupported.kt).
+
+When adding a new language there, you must also add the corresponding plural-selection rule in [LanguagePluralRules.kt](linguine-runtime/src/commonMain/kotlin/com/qinshift/linguine/linguineruntime/presentation/LanguagePluralRules.kt).
+
+`Localiser.configureDefaultLocalization(...)` accepts any non-blank language code. If plural lookup later uses a language that is not listed in `LanguagePluralSupported`, the runtime fails with an explicit error when it first tries to resolve a plural form for that language.
+
+Expected runtime asset names:
+
+- `strings.json` for the fallback localization
+- `strings-en.json`
+- `strings-cs.json`
+- `strings-sk.json`
+- `strings-fr.json`
+- `strings-es.json`
+
+If you configure `Localiser.configureDefaultLocalization("cs")`, the runtime will interpret `strings.json` using Czech plural rules.
+
+---
+
+## Known Considerations
+
+These points describe intentional contract boundaries and areas that should be handled carefully when changing provider integration, generator validation, or runtime parsing.
+
+- Placeholder validation is focused on supported `%s`, `%d`, `%f` placeholders and their indexed variants. Unsupported printf-like tokens such as `%q`, `%1$q`, or incomplete forms such as `%1$` are not part of the supported contract and should not be emitted by localization providers.
+- Runtime JSON syntax errors are currently logged and treated as empty localisation data, while semantic localisation errors such as invalid plural objects fail fast. This preserves compatibility, but stricter asset validation may require changing malformed JSON handling to fail fast as well.
+- Runtime formatting trusts templates to follow the generator contract. If assets bypass generated accessors or are edited manually, mixed indexed/unindexed placeholders, skipped indexes, or multiple unindexed placeholders are not guaranteed to behave like generator-validated templates.
 
 ---
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,11 @@ subprojects {
                     name.set("Bořek Leikep")
                     url.set("https://github.com/gerak-cz")
                 }
+                developer {
+                    id.set("savrov")
+                    name.set("Pavel Savrov")
+                    url.set("https://github.com/savrov")
+                }
             }
             scm {
                 url.set("https://github.com/cleverlance/linguine/")

--- a/linguine-generator/build.gradle.kts
+++ b/linguine-generator/build.gradle.kts
@@ -14,6 +14,10 @@ dependencies {
     testImplementation(libs.mockk)
 }
 
+kotlin {
+    explicitApi()
+}
+
 buildConfig {
     buildConfigField("GROUP", project.group as String)
     buildConfigField("VERSION", project.version as String)

--- a/linguine-generator/src/functionalTest/kotlin/com/qinshift/linguine/linguinegenerator/FileContentGeneratorTest.kt
+++ b/linguine-generator/src/functionalTest/kotlin/com/qinshift/linguine/linguinegenerator/FileContentGeneratorTest.kt
@@ -1,35 +1,32 @@
 package com.qinshift.linguine.linguinegenerator
 
 import io.kotest.matchers.shouldBe
+import java.nio.file.Path
+import java.util.Locale
 import kotlin.io.path.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-@Suppress("StringLiteralDuplication")
-class FileContentGeneratorTest {
+@Suppress("StringLiteralDuplication", "LargeClass")
+internal class FileContentGeneratorTest {
 
     @Test
     fun `generateFileContent with overlapping key names produces differentiated Kotlin object structures`() {
         val sourceRoot = Path("src/main/kotlin")
         val outputDirectory = Path("src/main/kotlin/com/example/app/")
-        val fileContent: Map<String, String> = mapOf(
-            "settings__privacy__title" to "Title for Privacy Settings",
-            "settings__privacy" to "Privacy Settings",
-            "settings__title" to "Title for Settings",
-        )
-
-        val root: Map<String, Any> = mapOf(
-            "Privacy" to mapOf(
-                "title" to ("settings__privacy__title" to "Title for Privacy Settings"),
+        val root = group(
+            "Privacy" to group(
+                "title" to leaf("settings__privacy__title", "Title for Privacy Settings"),
             ),
-            "privacy" to ("settings__privacy" to "Privacy Settings"),
-            "title" to ("settings__title" to "Title for Settings"),
+            "privacy" to leaf("settings__privacy", "Privacy Settings"),
+            "title" to leaf("settings__title", "Title for Settings"),
         )
         val generator = FileContentGenerator(
             sourceRoot = sourceRoot,
             outputDirectory = outputDirectory,
-            fileContent = fileContent,
             outputSuffix = "Strings",
         )
 
@@ -62,17 +59,12 @@ class FileContentGeneratorTest {
     fun `generateFileContent with empty values produces valid Kotlin object structures`() {
         val sourceRoot = Path("src/main/kotlin")
         val outputDirectory = Path("src/main/kotlin/com/example/app/")
-        val fileContent: Map<String, String> = mapOf(
-            "section__empty_value" to "",
-        )
-
-        val root: Map<String, Any> = mapOf(
-            "emptyValue" to ("section__empty_value" to ""),
+        val root = group(
+            "emptyValue" to leaf("section__empty_value", ""),
         )
         val generator = FileContentGenerator(
             sourceRoot = sourceRoot,
             outputDirectory = outputDirectory,
-            fileContent = fileContent,
             outputSuffix = "Strings",
         )
 
@@ -99,15 +91,11 @@ class FileContentGeneratorTest {
     fun `generateFileContent with deeply nested structures produces expected Kotlin object structure`() {
         val sourceRoot = Path("src/main/kotlin")
         val outputDirectory = Path("src/main/kotlin/com/example/app/")
-        val fileContent: Map<String, String> = mapOf(
-            "deep__level_one__level_two__level_three__final" to "Deeply Nested Value",
-        )
-
-        val root: Map<String, Any> = mapOf(
-            "LevelOne" to mapOf(
-                "LevelTwo" to mapOf(
-                    "LevelThree" to mapOf(
-                        "final" to ("deep__level_one__level_two__level_three__final" to "Deeply Nested Value"),
+        val root = group(
+            "LevelOne" to group(
+                "LevelTwo" to group(
+                    "LevelThree" to group(
+                        "final" to leaf("deep__level_one__level_two__level_three__final", "Deeply Nested Value"),
                     ),
                 ),
             ),
@@ -115,7 +103,6 @@ class FileContentGeneratorTest {
         val generator = FileContentGenerator(
             sourceRoot = sourceRoot,
             outputDirectory = outputDirectory,
-            fileContent = fileContent,
             outputSuffix = "Strings",
         )
 
@@ -146,19 +133,13 @@ class FileContentGeneratorTest {
     fun `generateFileContent with simple values produces expected Kotlin properties`() {
         val sourceRoot = Path("src/main/kotlin")
         val outputDirectory = Path("src/main/kotlin/com/example/app/")
-        val fileContent: Map<String, String> = mapOf(
-            "simple__key" to "Simple Value",
-            "another__simple__key" to "Another Simple Value",
-        )
-
-        val root: Map<String, Any> = mapOf(
-            "Simple" to ("simple__key" to "Simple Value"),
-            "AnotherSimple" to ("another__simple__key" to "Another Simple Value"),
+        val root = group(
+            "Simple" to leaf("simple__key", "Simple Value"),
+            "AnotherSimple" to leaf("another__simple__key", "Another Simple Value"),
         )
         val generator = FileContentGenerator(
             sourceRoot = sourceRoot,
             outputDirectory = outputDirectory,
-            fileContent = fileContent,
             outputSuffix = "Strings",
         )
 
@@ -184,20 +165,17 @@ class FileContentGeneratorTest {
     fun `generateFileContent with complex function parameterization generates correct function signatures`() {
         val sourceRoot = Path("src/main/kotlin")
         val outputDirectory = Path("src/main/kotlin/com/example/app/")
-        val fileContent: Map<String, String> = mapOf(
-            "error__message__with_parameters" to "Error %1\$s occurred at %2\$d:%3\$d on %4\$s",
-        )
-
-        val root: Map<String, Any> = mapOf(
-            "Error" to mapOf(
-                "messageWithParameters" to ("error__message__with_parameters" to
-                    "Error %1\$s occurred at %2\$d:%3\$d on %4\$s"),
+        val root = group(
+            "Error" to group(
+                "messageWithParameters" to leaf(
+                    "error__message__with_parameters",
+                    "Error %1\$s occurred at %2\$d:%3\$d on %4\$s",
+                ),
             ),
         )
         val generator = FileContentGenerator(
             sourceRoot = sourceRoot,
             outputDirectory = outputDirectory,
-            fileContent = fileContent,
             outputSuffix = "Strings",
         )
 
@@ -208,15 +186,14 @@ class FileContentGeneratorTest {
         package com.example.app
 
         import com.qinshift.linguine.linguineruntime.presentation.Localiser.localise
-        import kotlin.Int
         import kotlin.String
 
         public object Strings {
             public object Error {
                 public fun messageWithParameters(
                     param1: String,
-                    param2: Int,
-                    param3: Int,
+                    param2: String,
+                    param3: String,
                     param4: String,
                 ): String = localise("error__message__with_parameters", param1, param2, param3, param4)
             }
@@ -226,30 +203,521 @@ class FileContentGeneratorTest {
     }
 
     @Test
+    fun `generateFileContent allows single unindexed placeholder`() {
+        val sourceRoot = Path("src/main/kotlin")
+        val outputDirectory = Path("src/main/kotlin/com/example/app/")
+        val root = group(
+            "label" to leaf(
+                "sample__label",
+                "Value %s",
+            ),
+        )
+
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            outputSuffix = "Strings",
+        )
+
+        val result =
+            generator.generateFileContent(outputDirectory.resolve("SampleStrings.kt"), "SampleStrings", root)
+
+        assertTrue(result.contains("public fun label(param1: String): String"))
+    }
+
+    @Test
+    fun `generateFileContent fails when multiple placeholders contain unindexed placeholder`() {
+        val sourceRoot = Path("src/main/kotlin")
+        val outputDirectory = Path("src/main/kotlin/com/example/app/")
+        val root = group(
+            "label" to leaf(
+                "sample__label",
+                "%1\$s and %s",
+            ),
+        )
+
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            outputSuffix = "Strings",
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            val path = outputDirectory.resolve("SampleStrings.kt")
+            generator.generateFileContent(path, "SampleStrings", root)
+        }
+    }
+
+    @Test
+    fun `generateFileContent fails when placeholder has dollar without index`() {
+        val sourceRoot = Path("src/main/kotlin")
+        val outputDirectory = Path("src/main/kotlin/com/example/app/")
+        val root = group(
+            "label" to leaf(
+                "sample__label",
+                "Value %\$s",
+            ),
+        )
+
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            outputSuffix = "Strings",
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            val path = outputDirectory.resolve("SampleStrings.kt")
+            generator.generateFileContent(path, "SampleStrings", root)
+        }
+    }
+
+    @Test
+    fun `generateFileContent allows indexed placeholders in translated order`() {
+        val sourceRoot = Path("src/main/kotlin")
+        val outputDirectory = Path("src/main/kotlin/com/example/app/")
+        val root = group(
+            "label" to leaf(
+                "sample__label",
+                "%2\$s after %1\$s",
+            ),
+        )
+
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            outputSuffix = "Strings",
+        )
+
+        val result = generator.generateFileContent(
+            outputDirectory.resolve("SampleStrings.kt"),
+            "SampleStrings",
+            root,
+        )
+
+        assertTrue(result.contains("public fun label("))
+        assertTrue(result.contains("param1: String"))
+        assertTrue(result.contains("param2: String"))
+        assertTrue(Regex("""localise\("sample__label",\s*param1,\s*param2\)""").containsMatchIn(result))
+    }
+
+    @Test
+    fun `generateFileContent fails when indexed placeholders skip a parameter`() {
+        val sourceRoot = Path("src/main/kotlin")
+        val outputDirectory = Path("src/main/kotlin/com/example/app/")
+        val root = group(
+            "label" to leaf(
+                "sample__label",
+                "%1\$s and %3\$s",
+            ),
+        )
+
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            outputSuffix = "Strings",
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            generator.generateFileContent(
+                outputDirectory.resolve("SampleStrings.kt"),
+                "SampleStrings",
+                root,
+            )
+        }
+    }
+
+    @Test
+    fun `generateFileContent fails when indexed placeholder sequence starts after one`() {
+        val sourceRoot = Path("src/main/kotlin")
+        val outputDirectory = Path("src/main/kotlin/com/example/app/")
+        val root = group(
+            "label" to leaf(
+                "sample__label",
+                "%2\$s",
+            ),
+        )
+
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            outputSuffix = "Strings",
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            generator.generateFileContent(
+                outputDirectory.resolve("SampleStrings.kt"),
+                "SampleStrings",
+                root,
+            )
+        }
+    }
+
+    @Test
+    fun `generateFileContent with plural value generates plural accessor`() {
+        val sourceRoot = Path("src/main/kotlin")
+        val outputDirectory = Path("src/main/kotlin/com/example/app/")
+        val pluralEntry = Translation.Plural(
+            mapOf(
+                "zero" to "%1\$s items-zero",
+                "one" to "%1\$s item",
+                "few" to "%1\$s items-few",
+                "many" to "%1\$s items-many",
+                "other" to "%1\$s items",
+            ),
+        )
+
+        val root = group(
+            "Section" to group(
+                "itemCount" to pluralLeaf(
+                    "sample__section__item_count",
+                    pluralEntry,
+                ),
+            ),
+        )
+
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            outputSuffix = "Strings",
+        )
+
+        val path = outputDirectory.resolve("SampleStrings.kt")
+        val result = generator.generateFileContent(path, "SampleStrings", root)
+
+        val expected = """
+        package com.example.app
+
+        import com.qinshift.linguine.linguineruntime.presentation.Localiser.localise
+        import com.qinshift.linguine.linguineruntime.presentation.Localiser.localisePlural
+        import kotlin.Number
+        import kotlin.String
+
+        public object SampleStrings {
+            public object Section {
+                public fun itemCount(count: Number, param1: String): String =
+                        localisePlural("sample__section__item_count", count, param1)
+            }
+        }
+    """
+
+        assertEquals(expected.trimIndent(), result.trimIndent())
+    }
+
+    @Test
+    fun `generateFileContent creates one plural parameter for repeated single unindexed placeholders`() {
+        val sourceRoot = Path("src/main/kotlin")
+        val outputDirectory = Path("src/main/kotlin/com/example/app/")
+        val root = group(
+            "Section" to group(
+                "itemCount" to pluralLeaf(
+                    "sample__section__item_count",
+                    Translation.Plural(
+                        mapOf(
+                            "zero" to "%s items-zero",
+                            "one" to "%s item",
+                            "few" to "%s items-few",
+                            "many" to "%s items-many",
+                            "other" to "%s items",
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            outputSuffix = "Strings",
+        )
+
+        val result = generator.generateFileContent(
+            outputDirectory.resolve("SampleStrings.kt"),
+            "SampleStrings",
+            root,
+        )
+
+        assertTrue(result.contains("public fun itemCount(count: Number, param1: String): String"))
+        assertFalse(result.contains("param2: String"))
+    }
+
+    @Test
+    fun `generateFileContent with plural value without placeholders generates count-only plural accessor`() {
+        val sourceRoot = Path("src/main/kotlin")
+        val outputDirectory = Path("src/main/kotlin/com/example/app/")
+        val root = group(
+            "Section" to group(
+                "itemCount" to pluralLeaf(
+                    "sample__section__item_count",
+                    Translation.Plural(
+                        mapOf(
+                            "zero" to "No items",
+                            "one" to "One item",
+                            "few" to "Few items",
+                            "many" to "Many items",
+                            "other" to "Items",
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            outputSuffix = "Strings",
+        )
+
+        val path = outputDirectory.resolve("SampleStrings.kt")
+        val result = generator.generateFileContent(path, "SampleStrings", root)
+
+        assertTrue(result.contains("public fun itemCount(count: Number): String"))
+        assertTrue(result.contains("""localisePlural("sample__section__item_count","""))
+        assertTrue(result.contains("count)"))
+        assertFalse(result.contains("count, )"))
+    }
+
+    @Test
+    fun `generateFileContent creates localise function with parameter count and types matching placeholders`() {
+        val sourceRoot = Path("src/main/kotlin")
+        val outputDirectory = Path("src/main/kotlin/com/example/app/")
+        val root = group(
+            "Section" to group(
+                "formattedLabel" to leaf(
+                    "sample__section__formatted_label",
+                    "Value %1\$s / %2\$d / %3\$f",
+                ),
+            ),
+        )
+
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            outputSuffix = "Strings",
+        )
+
+        val path = outputDirectory.resolve("SampleStrings.kt")
+        val result = generator.generateFileContent(path, "SampleStrings", root)
+
+        assertTrue(result.contains("public fun formattedLabel("))
+        assertTrue(result.contains("param1: String"))
+        assertTrue(result.contains("param2: String"))
+        assertTrue(result.contains("param3: String"))
+    }
+
+    @Test
+    fun `generateFileContent creates localisePlural function with parameter count and types matching placeholders`() {
+        val sourceRoot = Path("src/main/kotlin")
+        val outputDirectory = Path("src/main/kotlin/com/example/app/")
+        val root = group(
+            "Section" to group(
+                "formattedCount" to pluralLeaf(
+                    "sample__section__formatted_count",
+                    Translation.Plural(
+                        mapOf(
+                            "zero" to "%1\$s / %2\$d / %3\$f",
+                            "one" to "%1\$s",
+                            "few" to "%1\$s / %2\$d / %3\$f",
+                            "many" to "%1\$s / %2\$d / %3\$f",
+                            "other" to "%1\$s / %2\$d / %3\$f",
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            outputSuffix = "Strings",
+        )
+
+        val path = outputDirectory.resolve("SampleStrings.kt")
+        val result = generator.generateFileContent(path, "SampleStrings", root)
+
+        assertTrue(result.contains("public fun formattedCount("))
+        assertTrue(result.contains("count: Number"))
+        assertTrue(result.contains("param1: String"))
+        assertTrue(result.contains("param2: String"))
+        assertTrue(result.contains("param3: String"))
+    }
+
+    @Test
+    fun `generateFileContent creates plural signature from different indexed subsets when union is sequential`() {
+        val sourceRoot = Path("src/main/kotlin")
+        val outputDirectory = Path("src/main/kotlin/com/example/app/")
+        val root = group(
+            "Section" to group(
+                "scopeValue" to pluralLeaf(
+                    "sample__section__scope_value",
+                    Translation.Plural(
+                        mapOf(
+                            "zero" to "%1\$s zero",
+                            "one" to "%1\$s one",
+                            "few" to "%1\$s few %3\$s",
+                            "many" to "N/A %2\$s",
+                            "other" to "%1\$s other %2\$s %3\$s",
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            outputSuffix = "Strings",
+        )
+
+        val result = generator.generateFileContent(
+            outputDirectory.resolve("SampleStrings.kt"),
+            "SampleStrings",
+            root,
+        )
+
+        assertTrue(result.contains("public fun scopeValue("))
+        assertTrue(result.contains("count: Number"))
+        assertTrue(result.contains("param1: String"))
+        assertTrue(result.contains("param2: String"))
+        assertTrue(result.contains("param3: String"))
+        assertFalse(result.contains("param4: String"))
+    }
+
+    @Test
+    fun `generateFileContent fails when plural indexed placeholder union is not sequential`() {
+        val sourceRoot = Path("src/main/kotlin")
+        val outputDirectory = Path("src/main/kotlin/com/example/app/")
+        val root = group(
+            "Section" to group(
+                "scopeValue" to pluralLeaf(
+                    "sample__section__scope_value",
+                    Translation.Plural(
+                        mapOf(
+                            "zero" to "%1\$s zero",
+                            "one" to "%1\$s one",
+                            "few" to "%1\$s few",
+                            "many" to "%3\$s many",
+                            "other" to "%1\$s other",
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            outputSuffix = "Strings",
+        )
+
+        assertFailsWith<IllegalArgumentException> {
+            generator.generateFileContent(
+                outputDirectory.resolve("SampleStrings.kt"),
+                "SampleStrings",
+                root,
+            )
+        }
+    }
+
+    @Test
+    fun `generateFileContent creates plural signature from placeholders across all forms`() {
+        val sourceRoot = Path("src/main/kotlin")
+        val outputDirectory = Path("src/main/kotlin/com/example/app/")
+        val root = group(
+            "Section" to group(
+                "scopeValue" to pluralLeaf(
+                    "sample__section__scope_value",
+                    Translation.Plural(
+                        mapOf(
+                            "zero" to "%1\$s zero %4\$s",
+                            "one" to "%1\$s one",
+                            "few" to "%1\$s few %2\$s",
+                            "many" to "%1\$s many %3\$s",
+                            "other" to "%1\$s other",
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            outputSuffix = "Strings",
+        )
+
+        val path = outputDirectory.resolve("SampleStrings.kt")
+        val result = generator.generateFileContent(path, "SampleStrings", root)
+
+        assertTrue(result.contains("public fun scopeValue("))
+        assertTrue(result.contains("count: Number"))
+        assertTrue(result.contains("param1: String"))
+        assertTrue(result.contains("param2: String"))
+        assertTrue(result.contains("param3: String"))
+        assertTrue(result.contains("param4: String"))
+        assertTrue(Regex("""param1,\s*param2,\s*param3,\s*param4""").containsMatchIn(result))
+    }
+
+    @Test
+    fun `generateFileContent creates plural signature with all indexed placeholder parameters`() {
+        val sourceRoot = Path("src/main/kotlin")
+        val outputDirectory = Path("src/main/kotlin/com/example/app/")
+        val root = group(
+            "Section" to group(
+                "scopeValue" to pluralLeaf(
+                    "sample__section__scope_value",
+                    Translation.Plural(
+                        mapOf(
+                            "zero" to "%1\$d zero %2\$s",
+                            "one" to "%1\$d singular %2\$s",
+                            "few" to "%1\$d few %2\$s",
+                            "many" to "N/A %2\$s",
+                            "other" to "%1\$d other %2\$s",
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val generator = FileContentGenerator(
+            sourceRoot = sourceRoot,
+            outputDirectory = outputDirectory,
+            outputSuffix = "Strings",
+        )
+
+        val path = outputDirectory.resolve("SampleStrings.kt")
+        val result = generator.generateFileContent(path, "SampleStrings", root)
+
+        assertTrue(result.contains("public fun scopeValue("))
+        assertTrue(result.contains("count: Number"))
+        assertTrue(result.contains("param1: String"))
+        assertTrue(result.contains("param2: String"))
+    }
+
+    @Test
     fun `generateFileContent with special characters in keys produces expected Kotlin object structure`() {
         val sourceRoot = Path("src/main/kotlin")
         val outputDirectory = Path("src/main/kotlin/com/example/app/")
-        val fileContent: Map<String, String> = mapOf(
-            "special__char@cters__key!__value" to "Special Value",
-            "another__special__key__with_numbers123" to "Numbered Value",
-        )
-
-        val root: Map<String, Any> = mapOf(
-            "Special" to mapOf(
-                "Characters" to mapOf(
-                    "Key" to mapOf(
-                        "value" to ("special__char@cters__key!__value" to "Special Value"),
+        val root = group(
+            "Special" to group(
+                "Characters" to group(
+                    "Key" to group(
+                        "value" to leaf(
+                            "special__char@cters__key!__value",
+                            "Special Value",
+                        ),
                     ),
                 ),
-                "AnotherSpecial" to mapOf(
-                    "keyWithNumbers123" to ("another__special__key__with_numbers123" to "Numbered Value"),
+                "AnotherSpecial" to group(
+                    "keyWithNumbers123" to leaf(
+                        "another__special__key__with_numbers123",
+                        "Numbered Value",
+                    ),
                 ),
             ),
         )
         val generator = FileContentGenerator(
             sourceRoot = sourceRoot,
             outputDirectory = outputDirectory,
-            fileContent = fileContent,
             outputSuffix = "Strings",
         )
 
@@ -285,44 +753,56 @@ class FileContentGeneratorTest {
     fun `generateFileContent with simple map produces expected Kotlin object structure`() {
         val sourceRoot = Path("src/main/kotlin")
         val outputDirectory = Path("src/main/kotlin/com/example/app/")
-        val fileContent: Map<String, String> = mapOf(
-            "activation__forgotten_password__birthdate__cancel_button" to "Cancel",
-            "activation__forgotten_password__email_input" to "Enter your email",
-            "home__welcome_message" to "Welcome to our application!",
-            "profile__settings__privacy__title" to "Privacy Settings",
-            "profile__settings__privacy__description" to "Manage your privacy settings here.",
-            "checkout__payment__credit_card__number_input" to "Credit Card Number",
-            "checkout__payment__credit_card__expiry_date" to "Expiry Date",
-            "checkout__payment__credit_card__cvv" to "CVV",
-        )
-
-        val root: Map<String, Any> = mapOf(
-            "Activation" to mapOf(
-                "ForgottenPassword" to mapOf(
-                    "Birthdate" to mapOf(
-                        "cancelButton" to ("activation__forgotten_password__birthdate__cancel_button" to "Cancel"),
+        val root = group(
+            "Activation" to group(
+                "ForgottenPassword" to group(
+                    "Birthdate" to group(
+                        "cancelButton" to leaf(
+                            "activation__forgotten_password__birthdate__cancel_button",
+                            "Cancel",
+                        ),
                     ),
-                    "emailInput" to ("activation__forgotten_password__email_input" to "Enter your email"),
-                ),
-            ),
-            "Home" to mapOf(
-                "welcomeMessage" to ("home__welcome_message" to "Welcome to our application!"),
-            ),
-            "Profile" to mapOf(
-                "Settings" to mapOf(
-                    "Privacy" to mapOf(
-                        "title" to ("profile__settings__privacy__title" to "Privacy Settings"),
-                        "description" to ("profile__settings__privacy__description" to
-                            "Manage your privacy settings here."),
+                    "emailInput" to leaf(
+                        "activation__forgotten_password__email_input",
+                        "Enter your email",
                     ),
                 ),
             ),
-            "Checkout" to mapOf(
-                "Payment" to mapOf(
-                    "CreditCard" to mapOf(
-                        "numberInput" to ("checkout__payment__credit_card__number_input" to "Credit Card Number"),
-                        "expiryDate" to ("checkout__payment__credit_card__expiry_date" to "Expiry Date"),
-                        "cvv" to ("checkout__payment__credit_card__cvv" to "CVV"),
+            "Home" to group(
+                "welcomeMessage" to leaf(
+                    "home__welcome_message",
+                    "Welcome to our application!",
+                ),
+            ),
+            "Profile" to group(
+                "Settings" to group(
+                    "Privacy" to group(
+                        "title" to leaf(
+                            "profile__settings__privacy__title",
+                            "Privacy Settings",
+                        ),
+                        "description" to leaf(
+                            "profile__settings__privacy__description",
+                            "Manage your privacy settings here.",
+                        ),
+                    ),
+                ),
+            ),
+            "Checkout" to group(
+                "Payment" to group(
+                    "CreditCard" to group(
+                        "numberInput" to leaf(
+                            "checkout__payment__credit_card__number_input",
+                            "Credit Card Number",
+                        ),
+                        "expiryDate" to leaf(
+                            "checkout__payment__credit_card__expiry_date",
+                            "Expiry Date",
+                        ),
+                        "cvv" to leaf(
+                            "checkout__payment__credit_card__cvv",
+                            "CVV",
+                        ),
                     ),
                 ),
             ),
@@ -330,12 +810,11 @@ class FileContentGeneratorTest {
         val generator = FileContentGenerator(
             sourceRoot = sourceRoot,
             outputDirectory = outputDirectory,
-            fileContent = fileContent,
             outputSuffix = "Strings",
         )
 
-        val result =
-            generator.generateFileContent(outputDirectory.resolve("Strings.kt"), "Strings", root)
+        val path = outputDirectory.resolve("Strings.kt")
+        val result = generator.generateFileContent(path, "Strings", root)
 
         val expected = """
         package com.example.app
@@ -391,16 +870,14 @@ class FileContentGeneratorTest {
     fun `generateFileContent with function parameters generates kotlin object with function parameters`() {
         val sourceRoot = Path("src/main/kotlin")
         val outputDirectory = Path("src/main/kotlin/com/example/app/")
-        val fileContent: Map<String, String> = mapOf(
-            "activation__forgotten_password__birthdate__cancel_button" to "\"%s %d %f %${'$'}s %${'$'}d %${'$'}f\"",
-        )
-
-        val root: Map<String, Any> = mapOf(
-            "Activation" to mapOf(
-                "ForgottenPassword" to mapOf(
-                    "Birthdate" to mapOf(
-                        "cancelButton" to ("activation__forgotten_password__birthdate__cancel_button" to
-                            "\"%s %d %f %${'$'}s %${'$'}d %${'$'}f\""),
+        val root = group(
+            "Activation" to group(
+                "ForgottenPassword" to group(
+                    "Birthdate" to group(
+                        "cancelButton" to leaf(
+                            "activation__forgotten_password__birthdate__cancel_button",
+                            "\"%1${'$'}s %2${'$'}d %3${'$'}f %4${'$'}s %5${'$'}d %6${'$'}f\"",
+                        ),
                     ),
                 ),
             ),
@@ -408,19 +885,16 @@ class FileContentGeneratorTest {
         val generator = FileContentGenerator(
             sourceRoot = sourceRoot,
             outputDirectory = outputDirectory,
-            fileContent = fileContent,
             outputSuffix = "Strings",
         )
 
-        val result =
-            generator.generateFileContent(outputDirectory.resolve("Strings.kt"), "Strings", root)
+        val path = outputDirectory.resolve("Strings.kt")
+        val result = generator.generateFileContent(path, "Strings", root)
 
         val expected = """
             package com.example.app
             
             import com.qinshift.linguine.linguineruntime.presentation.Localiser.localise
-            import kotlin.Float
-            import kotlin.Int
             import kotlin.String
             
             public object Strings {
@@ -429,11 +903,11 @@ class FileContentGeneratorTest {
                         public object Birthdate {
                             public fun cancelButton(
                                 param1: String,
-                                param2: Int,
-                                param3: Float,
+                                param2: String,
+                                param3: String,
                                 param4: String,
-                                param5: Int,
-                                param6: Float,
+                                param5: String,
+                                param6: String,
                             ): String = localise("activation__forgotten_password__birthdate__cancel_button",
                                     param1, param2, param3, param4, param5, param6)
                         }
@@ -448,20 +922,15 @@ class FileContentGeneratorTest {
     fun `generateFileContents uses outputSuffix in file name and root object name`() {
         val sourceRoot = Path("src/main/kotlin")
         val outputDirectory = Path("src/main/kotlin/com/example/app/")
-        val fileContent: Map<String, String> = mapOf(
-            "home__title" to "Home Title",
-        )
-
-        val groupedMap: Map<String, Map<String, Any>> = mapOf(
-            "Home" to mapOf(
-                "title" to ("home__title" to "Home Title"),
+        val groupedMap = mapOf(
+            "Home" to group(
+                "title" to leaf("home__title", "Home Title"),
             ),
         )
 
         val generator = FileContentGenerator(
             sourceRoot = sourceRoot,
             outputDirectory = outputDirectory,
-            fileContent = fileContent,
             outputSuffix = "L10n",
         )
 
@@ -473,35 +942,24 @@ class FileContentGeneratorTest {
 
         path shouldBe outputDirectory.resolve("HomeL10n.kt")
 
-        assertTrue(
-            content.contains("public object HomeL10n"),
-            "Expected root object 'HomeL10n' in generated content, but was:\n$content",
-        )
+        assertTrue(content.contains("public object HomeL10n"))
 
-        assertTrue(
-            content.contains("""public val title: String = localise("home__title")"""),
-            "Expected property for 'home__title' in generated content, but was:\n$content",
-        )
+        assertTrue(content.contains("""public val title: String = localise("home__title")"""))
     }
 
     @Test
     fun `generateFileContents capitalizes lowercase group name and applies suffix`() {
         val sourceRoot = Path("src/main/kotlin")
         val outputDirectory = Path("src/main/kotlin/com/example/app/")
-        val fileContent: Map<String, String> = mapOf(
-            "home__title" to "Home Title",
-        )
-
-        val groupedMap: Map<String, Map<String, Any>> = mapOf(
-            "home" to mapOf(
-                "title" to ("home__title" to "Home Title"),
+        val groupedMap = mapOf(
+            "home" to group(
+                "title" to leaf("home__title", "Home Title"),
             ),
         )
 
         val generator = FileContentGenerator(
             sourceRoot = sourceRoot,
             outputDirectory = outputDirectory,
-            fileContent = fileContent,
             outputSuffix = "L10n",
         )
 
@@ -513,33 +971,57 @@ class FileContentGeneratorTest {
 
         path shouldBe outputDirectory.resolve("HomeL10n.kt")
 
-        assertTrue(
-            content.contains("public object HomeL10n"),
-            "Expected root object 'HomeL10n' in generated content, but was:\n$content",
-        )
+        assertTrue(content.contains("public object HomeL10n"))
 
-        assertTrue(
-            content.contains("""public val title: String = localise("home__title")"""),
-            "Expected property for 'home__title' in generated content, but was:\n$content",
-        )
+        assertTrue(content.contains("""public val title: String = localise("home__title")"""))
+    }
+
+    @Test
+    fun `generateFileContents capitalizes identifiers independent from default locale`() {
+        val previousLocale = Locale.getDefault()
+
+        try {
+            Locale.setDefault(Locale.forLanguageTag("tr"))
+
+            val sourceRoot = Path("src/main/kotlin")
+            val outputDirectory = Path("src/main/kotlin/com/example/app/")
+            val groupedMap = mapOf(
+                "item" to group(
+                    "inner" to group(
+                        "title" to leaf("item__inner__title", "Item Title"),
+                    ),
+                ),
+            )
+
+            val generator = FileContentGenerator(
+                sourceRoot = sourceRoot,
+                outputDirectory = outputDirectory,
+                outputSuffix = "L10n",
+            )
+
+            val result = generator.generateFileContents(groupedMap)
+            val (path, content) = result.entries.single()
+
+            path shouldBe outputDirectory.resolve("ItemL10n.kt")
+            assertTrue(content.contains("public object ItemL10n"))
+            assertTrue(content.contains("public object Inner"))
+            assertFalse(content.contains("İ"))
+        } finally {
+            Locale.setDefault(previousLocale)
+        }
     }
 
     @Test
     fun `generateFileContent falls back to presentation package when relative path is blank`() {
         val sourceRoot = Path("src/main/kotlin/com/example/app")
         val outputDirectory = Path("src/main/kotlin/com/example/app")
-        val fileContent: Map<String, String> = mapOf(
-            "key" to "Value",
-        )
-
-        val root: Map<String, Any> = mapOf(
-            "key" to ("key" to "Value"),
+        val root = group(
+            "key" to leaf("key", "Value"),
         )
 
         val generator = FileContentGenerator(
             sourceRoot = sourceRoot,
             outputDirectory = outputDirectory,
-            fileContent = fileContent,
             outputSuffix = "Strings",
         )
 
@@ -549,35 +1031,41 @@ class FileContentGeneratorTest {
             root,
         )
 
-        assertTrue(
-            result.trimStart().startsWith("package presentation"),
-            "Expected fallback package 'presentation' but was:\n$result",
-        )
+        assertTrue(result.trimStart().startsWith("package presentation"))
     }
 
     @Test
     fun `generateFileContent falls back to property when translation key is missing`() {
         val sourceRoot = Path("src/main/kotlin")
         val outputDirectory = Path("src/main/kotlin/com/example/app/")
-        val fileContent: Map<String, String> = emptyMap()
-
-        val root: Map<String, Any> = mapOf(
-            "title" to ("missing_key" to "This value is ignored by generator"),
+        val root = group(
+            "title" to leaf("missing_key", "This value is ignored by generator"),
         )
 
         val generator = FileContentGenerator(
             sourceRoot = sourceRoot,
             outputDirectory = outputDirectory,
-            fileContent = fileContent,
             outputSuffix = "Strings",
         )
 
         val result =
             generator.generateFileContent(outputDirectory.resolve("Strings.kt"), "Strings", root)
 
-        assertTrue(
-            result.contains("""public val title: String = localise("missing_key")"""),
-            "Expected fallback property for missing key in generated content, but was:\n$result",
-        )
+        assertTrue(result.contains("""public val title: String = localise("missing_key")"""))
     }
+
+    private fun group(vararg children: Pair<String, Node>): Node.Group =
+        Node.Group(children.toMap())
+
+    private fun leaf(originalKey: String, value: String): Node.Item =
+        Node.Item(
+            key = originalKey,
+            translation = Translation.Text(value),
+        )
+
+    private fun pluralLeaf(originalKey: String, value: Translation.Plural): Node.Item =
+        Node.Item(
+            key = originalKey,
+            translation = value,
+        )
 }

--- a/linguine-generator/src/functionalTest/kotlin/com/qinshift/linguine/linguinegenerator/FileParserTest.kt
+++ b/linguine-generator/src/functionalTest/kotlin/com/qinshift/linguine/linguinegenerator/FileParserTest.kt
@@ -12,9 +12,9 @@ class FileParserTest {
         val mapContent: Map<String, String> = emptyMap()
         val fileParser = fileParser(fileContent = mapContent)
 
-        val expectedOutput = mapOf<String, Any>()
+        val expectedOutput = emptyMap<String, Node.Group>()
 
-        val result = fileParser.generateGroupedMapStructure()
+        val result = fileParser.generateGroupedNodeStructure()
 
         result shouldBe expectedOutput
     }
@@ -27,10 +27,12 @@ class FileParserTest {
         val fileParser = fileParser(fileContent = mapContent)
 
         val expectedOutput = mapOf(
-            "SingleKey" to mapOf("singleKey" to ("singleKey" to "Single Value")),
+            "SingleKey" to nodeGroup(
+                "singleKey" to nodeItem("singleKey", "Single Value"),
+            ),
         )
 
-        val result = fileParser.generateGroupedMapStructure()
+        val result = fileParser.generateGroupedNodeStructure()
 
         result shouldBe expectedOutput
     }
@@ -43,14 +45,17 @@ class FileParserTest {
         val fileParser = fileParser(fileContent = mapContent)
 
         val expectedOutput = mapOf(
-            "Activation" to mapOf(
-                "ForgottenPassword" to mapOf(
-                    "emailInput" to ("activation__forgottenPassword__emailInput" to "Enter your email")
-                )
-            )
+            "Activation" to nodeGroup(
+                "ForgottenPassword" to nodeGroup(
+                    "emailInput" to nodeItem(
+                        "activation__forgottenPassword__emailInput",
+                        "Enter your email",
+                    ),
+                ),
+            ),
         )
 
-        val result = fileParser.generateGroupedMapStructure()
+        val result = fileParser.generateGroupedNodeStructure()
 
         result shouldBe expectedOutput
     }
@@ -63,22 +68,26 @@ class FileParserTest {
         val fileParser = fileParser(fileContent = mapContent)
 
         val expectedOutput = mapOf(
-            "Activation" to mapOf(
-                "" to mapOf(
-                    "ForgottenPassword" to mapOf(
-                        "Email" to mapOf(
-                            "input" to ("activation____forgotten_password__email__input" to "Email Input"),
+            "Activation" to nodeGroup(
+                "" to nodeGroup(
+                    "ForgottenPassword" to nodeGroup(
+                        "Email" to nodeGroup(
+                            "input" to nodeItem(
+                                "activation____forgotten_password__email__input",
+                                "Email Input",
+                            ),
                         ),
                     ),
                 ),
             ),
         )
 
-        val result = fileParser.generateGroupedMapStructure()
+        val result = fileParser.generateGroupedNodeStructure()
 
         result shouldBe expectedOutput
     }
 
+    @Suppress("LongMethod")
     @Test
     fun `generateNestedMapStructure with valid input creates correct nested structure`() {
         val mapContent: Map<String, String> = mapOf(
@@ -94,38 +103,58 @@ class FileParserTest {
         val fileParser = fileParser(fileContent = mapContent)
 
         val expectedOutput = mapOf(
-            "Activation" to mapOf(
-                "ForgottenPassword" to mapOf(
-                    "Birthdate" to mapOf(
-                        "cancelButton" to ("activation__forgotten_password__birthdate__cancel_button" to "Cancel"),
+            "Activation" to nodeGroup(
+                "ForgottenPassword" to nodeGroup(
+                    "Birthdate" to nodeGroup(
+                        "cancelButton" to nodeItem(
+                            "activation__forgotten_password__birthdate__cancel_button",
+                            "Cancel",
+                        ),
                     ),
-                    "emailInput" to ("activation__forgotten_password__email_input" to "Enter your email"),
-                ),
-            ),
-            "Home" to mapOf(
-                "welcomeMessage" to ("home__welcome_message" to "Welcome to our application!"),
-            ),
-            "Profile" to mapOf(
-                "Settings" to mapOf(
-                    "Privacy" to mapOf(
-                        "title" to ("profile__settings__privacy__title" to "Privacy Settings"),
-                        "description" to ("profile__settings__privacy__description" to
-                            "Manage your privacy settings here."),
+                    "emailInput" to nodeItem(
+                        "activation__forgotten_password__email_input",
+                        "Enter your email",
                     ),
                 ),
             ),
-            "Checkout" to mapOf(
-                "Payment" to mapOf(
-                    "CreditCard" to mapOf(
-                        "numberInput" to ("checkout__payment__credit_card__number_input" to "Credit Card Number"),
-                        "expiryDate" to ("checkout__payment__credit_card__expiry_date" to "Expiry Date"),
-                        "cvv" to ("checkout__payment__credit_card__cvv" to "CVV"),
+            "Home" to nodeGroup(
+                "welcomeMessage" to nodeItem(
+                    "home__welcome_message",
+                    "Welcome to our application!",
+                ),
+            ),
+            "Profile" to nodeGroup(
+                "Settings" to nodeGroup(
+                    "Privacy" to nodeGroup(
+                        "title" to nodeItem(
+                            "profile__settings__privacy__title",
+                            "Privacy Settings",
+                        ),
+                        "description" to nodeItem(
+                            "profile__settings__privacy__description",
+                            "Manage your privacy settings here.",
+                        ),
+                    ),
+                ),
+            ),
+            "Checkout" to nodeGroup(
+                "Payment" to nodeGroup(
+                    "CreditCard" to nodeGroup(
+                        "numberInput" to nodeItem(
+                            "checkout__payment__credit_card__number_input",
+                            "Credit Card Number",
+                        ),
+                        "expiryDate" to nodeItem(
+                            "checkout__payment__credit_card__expiry_date",
+                            "Expiry Date",
+                        ),
+                        "cvv" to nodeItem("checkout__payment__credit_card__cvv", "CVV"),
                     ),
                 ),
             ),
         )
 
-        val result = fileParser.generateGroupedMapStructure()
+        val result = fileParser.generateGroupedNodeStructure()
 
         result shouldBe expectedOutput
     }
@@ -139,20 +168,25 @@ class FileParserTest {
         val fileParser = fileParser(fileContent = mapContent)
 
         val expectedOutput = mapOf(
-            "Profile" to mapOf(
-                "Settings" to mapOf(
-                    "Privacy" to mapOf(
-                        "privacyPolicy" to ("profile__settings__privacy__privacy_policy" to "Privacy Policy"),
-                        "PrivacyPolicy" to mapOf(
-                            "details" to ("profile__settings__privacy__privacy_policy__details" to
-                                "Detailed description")
-                        )
+            "Profile" to nodeGroup(
+                "Settings" to nodeGroup(
+                    "Privacy" to nodeGroup(
+                        "privacyPolicy" to nodeItem(
+                            "profile__settings__privacy__privacy_policy",
+                            "Privacy Policy",
+                        ),
+                        "PrivacyPolicy" to nodeGroup(
+                            "details" to nodeItem(
+                                "profile__settings__privacy__privacy_policy__details",
+                                "Detailed description",
+                            ),
+                        ),
                     ),
                 ),
             ),
         )
 
-        val result = fileParser.generateGroupedMapStructure()
+        val result = fileParser.generateGroupedNodeStructure()
 
         result shouldBe expectedOutput
     }
@@ -166,19 +200,25 @@ class FileParserTest {
         val fileParser = fileParser(fileContent = mapContent)
 
         val expectedOutput = mapOf(
-            "System" to mapOf(
-                "Config" to mapOf(
-                    "Database" to mapOf(
-                        "Settings" to mapOf(
-                            "maxConnections" to ("system__config__database__settings__max_connections" to "100"),
-                            "timeout" to ("system__config__database__settings__timeout" to "30"),
+            "System" to nodeGroup(
+                "Config" to nodeGroup(
+                    "Database" to nodeGroup(
+                        "Settings" to nodeGroup(
+                            "maxConnections" to nodeItem(
+                                "system__config__database__settings__max_connections",
+                                "100",
+                            ),
+                            "timeout" to nodeItem(
+                                "system__config__database__settings__timeout",
+                                "30",
+                            ),
                         ),
                     ),
                 ),
             ),
         )
 
-        val result = fileParser.generateGroupedMapStructure()
+        val result = fileParser.generateGroupedNodeStructure()
 
         result shouldBe expectedOutput
     }
@@ -192,15 +232,15 @@ class FileParserTest {
         val fileParser = fileParser(fileContent = mapContent)
 
         val expectedOutput = mapOf(
-            "User" to mapOf(
-                "Name" to mapOf(
-                    "first name" to ("user__name__first name" to "John"),
-                    "last-name" to ("user__name__last-name" to "Doe"),
+            "User" to nodeGroup(
+                "Name" to nodeGroup(
+                    "first name" to nodeItem("user__name__first name", "John"),
+                    "last-name" to nodeItem("user__name__last-name", "Doe"),
                 ),
             ),
         )
 
-        val result = fileParser.generateGroupedMapStructure()
+        val result = fileParser.generateGroupedNodeStructure()
 
         result shouldBe expectedOutput
     }
@@ -214,4 +254,13 @@ class FileParserTest {
         minorDelimiter = minorDelimiter,
         majorDelimiter = majorDelimiter,
     )
+
+    private fun nodeGroup(vararg children: Pair<String, Node>): Node.Group =
+        Node.Group(children.toMap())
+
+    private fun nodeItem(originalKey: String, value: String): Node.Item =
+        Node.Item(
+            key = originalKey,
+            translation = Translation.Text(value),
+        )
 }

--- a/linguine-generator/src/functionalTest/kotlin/com/qinshift/linguine/linguinegenerator/LinguinePluginFunctionalTest.kt
+++ b/linguine-generator/src/functionalTest/kotlin/com/qinshift/linguine/linguinegenerator/LinguinePluginFunctionalTest.kt
@@ -19,7 +19,7 @@ class LinguinePluginFunctionalTest {
     private val gradleBuildFileName = "build.gradle.kts"
 
     @Test
-    fun whenGenerateTaskExecutedThenCompletedSuccessfully() {
+    fun `generate task completes successfully`() {
         File(testProjectDir, gradleBuildFileName).apply {
             writeText(
                 """
@@ -52,7 +52,7 @@ class LinguinePluginFunctionalTest {
 
     @Suppress("LongMethod")
     @Test
-    fun whenGenerateTaskExecutedThenOutputsFileContainsExpectedContent() {
+    fun `generate task outputs file with expected content`() {
         testProjectDir.resolve(gradleBuildFileName).apply {
             writeText(
                 """
@@ -77,7 +77,7 @@ class LinguinePluginFunctionalTest {
                 """
                 {
                     "activation__forgotten_password__birthdate__log_in": "Přihlásit se",
-                    "activation__forgotten_password__birthdate__log_out": "%s %d %f %${'$'}s %${'$'}d %${'$'}f"
+                    "activation__forgotten_password__birthdate__log_out": "%1${'$'}s %2${'$'}d %3${'$'}f %4${'$'}s %5${'$'}d %6${'$'}f"
                 }
                 """.trimIndent(),
             )
@@ -92,19 +92,17 @@ class LinguinePluginFunctionalTest {
 
         println(result.output)
 
-        assertTrue(result.output.contains(buildSuccessOutput), "Build should be successful")
+        assertTrue(result.output.contains(buildSuccessOutput))
 
         val generatedFile =
             File(testProjectDir, "src/main/kotlin/presentation/ActivationStrings.kt")
-        assertTrue(generatedFile.exists(), "Generated file should exist")
+        assertTrue(generatedFile.exists())
 
         val actualContent = generatedFile.readText()
         val expectedContent = """
             package presentation
             
             import com.qinshift.linguine.linguineruntime.presentation.Localiser.localise
-            import kotlin.Float
-            import kotlin.Int
             import kotlin.String
             
             public object ActivationStrings {
@@ -114,14 +112,13 @@ class LinguinePluginFunctionalTest {
                                 localise("activation__forgotten_password__birthdate__log_in")
         
                         public fun logOut(
-                            param1: String,
-                            param2: Int,
-                            param3: Float,
-                            param4: String,
-                            param5: Int,
-                            param6: Float,
-                        ): String = localise("activation__forgotten_password__birthdate__log_out",
-                                param1, param2, param3, param4, param5, param6)
+                                param1: String,
+                                param2: String,
+                                param3: String,
+                                param4: String,
+                                param5: String,
+                                param6: String,
+                            ): String = localise("activation__forgotten_password__birthdate__log_out", param1, param2, param3, param4, param5, param6)
                     }
                 }
             }
@@ -135,7 +132,7 @@ class LinguinePluginFunctionalTest {
     }
 
     @Test
-    fun whenGenerateTaskExecutedThenOutputFilePlacedInConfiguredPath() {
+    fun `generate task places output file in configured path`() {
         val testProjectDir = createTempDirectory().toFile()
         File(testProjectDir, "settings.gradle.kts").writeText("")
 
@@ -161,7 +158,7 @@ class LinguinePluginFunctionalTest {
                 """
                 {
                     "activation__forgotten_password__birthdate__log_in": "Přihlásit se",
-                    "activation__forgotten_password__birthdate__log_out": "%s %d %f %${'$'}s %${'$'}d %${'$'}f"
+                    "activation__forgotten_password__birthdate__log_out": "%1${'$'}s %2${'$'}d %3${'$'}f %4${'$'}s %5${'$'}d %6${'$'}f"
                 }
                 """.trimIndent(),
             )
@@ -174,30 +171,22 @@ class LinguinePluginFunctionalTest {
             .forwardOutput()
             .build()
 
-        assertTrue(result.output.contains(buildSuccessOutput), "Build should be successful")
+        assertTrue(result.output.contains(buildSuccessOutput))
 
-        val expectedSuccessMessagePart =
-            "File ActivationStrings.kt has been successfully created in the directory"
-        assertTrue(
-            result.output.contains(expectedSuccessMessagePart),
-            "Success message was not printed correctly",
-        )
+        val expectedSuccessMessagePart = "File ActivationStrings.kt has been successfully created in the directory"
+        assertTrue(result.output.contains(expectedSuccessMessagePart))
 
-        val expectedOutputPath =
-            Paths.get(testProjectDir.path, "presentation", "ActivationStrings.kt").toString()
-                .replace('\\', '/')
-        assertTrue(File(expectedOutputPath).exists(), "Output file should exist")
+        val expectedOutputPath = Paths.get(testProjectDir.path, "presentation", "ActivationStrings.kt").toString()
+            .replace('\\', '/')
+        assertTrue(File(expectedOutputPath).exists())
         val outputPathComponents = expectedOutputPath.split('/')
         outputPathComponents.forEach { component ->
-            assertTrue(
-                result.output.contains(component),
-                "Expected output path component '$component' was not found in the build output.",
-            )
+            assertTrue(result.output.contains(component))
         }
     }
 
     @Test
-    fun whenCustomOutputSuffixConfiguredThenFileAndRootObjectUseSuffix() {
+    fun `custom output suffix configures file and root object suffix`() {
         testProjectDir.resolve(gradleBuildFileName).apply {
             writeText(
                 """
@@ -233,25 +222,71 @@ class LinguinePluginFunctionalTest {
             .forwardOutput()
             .build()
 
-        assertTrue(result.output.contains(buildSuccessOutput), "Build should be successful")
+        assertTrue(result.output.contains(buildSuccessOutput))
 
         val generatedFile =
             File(testProjectDir, "src/main/kotlin/presentation/ActivationL10n.kt")
-        assertTrue(generatedFile.exists(), "Generated file with custom suffix should exist")
+        assertTrue(generatedFile.exists())
 
         val actualContent = generatedFile.readText()
 
-        assertTrue(
-            actualContent.contains("public object ActivationL10n"),
-            "Expected root object 'ActivationL10n' in generated content, but was:\n$actualContent",
-        )
+        assertTrue(actualContent.contains("public object ActivationL10n"))
         assertTrue(
             actualContent.contains(
                 """public val logIn: String = localise("activation__forgotten_password__birthdate__log_in")"""
                     .trimIndent(),
             ),
-            "Expected property 'logIn' in generated content, but was:\n$actualContent",
         )
+    }
+
+    @Test
+    fun `require other only policy accepts plural with other only`() {
+        testProjectDir.resolve(gradleBuildFileName).apply {
+            writeText(
+                """
+                import com.qinshift.linguine.linguinegenerator.PluralFormPolicy
+
+                plugins {
+                    id("com.qinshift.linguine")
+                }
+
+                linguine {
+                    inputFilePath = "src/main/resources/strings.json"
+                    outputFilePath = "src/main/kotlin/presentation"
+                    sourceRootPath = "src/main/kotlin"
+                    pluralFormPolicy = PluralFormPolicy.REQUIRE_OTHER_ONLY
+                }
+                """.trimIndent(),
+            )
+        }
+
+        testProjectDir.resolve("src/main/resources/strings.json").apply {
+            parentFile.mkdirs()
+            writeText(
+                """
+                {
+                    "sample__section__item_count": {
+                        "other": "%1${'$'}s items"
+                    }
+                }
+                """.trimIndent(),
+            )
+        }
+
+        val result = GradleRunner.create()
+            .withProjectDir(testProjectDir)
+            .withArguments(generateTaskName)
+            .withPluginClasspath()
+            .forwardOutput()
+            .build()
+
+        assertTrue(result.output.contains(buildSuccessOutput))
+
+        val generatedFile = File(testProjectDir, "src/main/kotlin/presentation/SampleStrings.kt")
+        assertTrue(generatedFile.exists())
+
+        val actualContent = generatedFile.readText()
+        assertTrue(actualContent.contains("public fun itemCount(count: Number, param1: String): String"))
     }
 
     private fun normalizeWhitespace(code: String): String =

--- a/linguine-generator/src/functionalTest/kotlin/com/qinshift/linguine/linguinegenerator/filereader/FileReaderTest.kt
+++ b/linguine-generator/src/functionalTest/kotlin/com/qinshift/linguine/linguinegenerator/filereader/FileReaderTest.kt
@@ -1,8 +1,11 @@
 package com.qinshift.linguine.linguinegenerator.filereader
 
+import com.qinshift.linguine.linguinegenerator.PluralFormPolicy
+import com.qinshift.linguine.linguinegenerator.Translation
 import java.io.File
-import org.gradle.internal.impldep.junit.framework.TestCase.assertEquals
+import kotlin.test.assertEquals
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.io.TempDir
 
 class FileReaderTest {
@@ -23,13 +26,233 @@ class FileReaderTest {
             )
         }
 
-        val fileReader = FileReader()
+        val fileReader = fileReader()
         val result = fileReader.read(file, FileType.JSON)
         val expectedResult = mapOf(
-            "test__file__input_value" to "Input Value",
-            "another__file__description_value" to "Description",
+            "test__file__input_value" to Translation.Text("Input Value"),
+            "another__file__description_value" to Translation.Text("Description"),
         )
 
         assertEquals(expectedResult, result)
+    }
+
+    @Test
+    @Suppress("StringLiteralDuplication")
+    fun `read should parse plural object values`() {
+        val file = File(testProjectDir, "plural-test.json").apply {
+            writeText(
+                """
+                {
+                    "sample__section__item_count": {
+                        "zero": "%1${'$'}s items-zero",
+                        "one": "%1${'$'}s item",
+                        "two": "%1${'$'}s items-two",
+                        "few": "%1${'$'}s items-few",
+                        "many": "%1${'$'}s items-many",
+                        "other": "%1${'$'}s items"
+                    }
+                }
+                """.trimIndent(),
+            )
+        }
+
+        val fileReader = fileReader()
+        val result = fileReader.read(file, FileType.JSON)
+        val expectedResult = mapOf(
+            "sample__section__item_count" to Translation.Plural(
+                mapOf(
+                    "zero" to "%1\$s items-zero",
+                    "one" to "%1\$s item",
+                    "two" to "%1\$s items-two",
+                    "few" to "%1\$s items-few",
+                    "many" to "%1\$s items-many",
+                    "other" to "%1\$s items",
+                ),
+            ),
+        )
+
+        assertEquals(expectedResult, result)
+    }
+
+    @Test
+    fun `read should fail when plural object does not contain all required forms`() {
+        val file = File(testProjectDir, "plural-missing-forms.json").apply {
+            writeText(
+                """
+                {
+                    "sample__section__item_count": {
+                        "one": "%1${'$'}s item",
+                        "other": "%1${'$'}s items"
+                    }
+                }
+                """.trimIndent(),
+            )
+        }
+
+        assertThrows<IllegalArgumentException> {
+            fileReader().read(file, FileType.JSON)
+        }
+    }
+
+    @Test
+    fun `read should validate every plural form combination with all forms policy`() {
+        pluralFormCombinations().forEach { forms ->
+            val file = writePluralFile("all-forms-${forms.joinToString("-")}.json", forms)
+
+            if (forms == REQUIRED_PLURAL_FORMS.toSet()) {
+                val result = fileReader().read(file, FileType.JSON)
+                assertEquals(
+                    Translation.Plural(REQUIRED_PLURAL_FORMS.associateWith { "$it value" }),
+                    result.getValue(PLURAL_KEY),
+                    "Expected all-forms policy to accept only complete plural form set: $forms",
+                )
+            } else {
+                assertThrows<IllegalArgumentException> {
+                    fileReader().read(file, FileType.JSON)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `read should parse plural object with other only policy`() {
+        val file = File(testProjectDir, "plural-other-only.json").apply {
+            writeText(
+                """
+                {
+                    "sample__section__item_count": {
+                        "other": "%1${'$'}s items"
+                    }
+                }
+                """.trimIndent(),
+            )
+        }
+
+        val result = fileReader(PluralFormPolicy.REQUIRE_OTHER_ONLY).read(file, FileType.JSON)
+        val expectedResult = mapOf(
+            "sample__section__item_count" to Translation.Plural(
+                mapOf(
+                    "other" to "%1\$s items",
+                ),
+            ),
+        )
+
+        assertEquals(expectedResult, result)
+    }
+
+    @Test
+    fun `read should fail when other only policy plural object does not contain other form`() {
+        val file = File(testProjectDir, "plural-missing-other.json").apply {
+            writeText(
+                """
+                {
+                    "sample__section__item_count": {
+                        "one": "%1${'$'}s item"
+                    }
+                }
+                """.trimIndent(),
+            )
+        }
+
+        assertThrows<IllegalArgumentException> {
+            fileReader(PluralFormPolicy.REQUIRE_OTHER_ONLY).read(file, FileType.JSON)
+        }
+    }
+
+    @Test
+    fun `read should validate every plural form combination with other only policy`() {
+        pluralFormCombinations().forEach { forms ->
+            val file = writePluralFile("other-only-${forms.joinToString("-")}.json", forms)
+
+            if ("other" in forms) {
+                val result = fileReader(PluralFormPolicy.REQUIRE_OTHER_ONLY).read(file, FileType.JSON)
+                assertEquals(
+                    Translation.Plural(forms.associateWith { "$it value" }),
+                    result.getValue(PLURAL_KEY),
+                    "Expected other-only policy to accept plural form set with other: $forms",
+                )
+            } else {
+                assertThrows<IllegalArgumentException> {
+                    fileReader(PluralFormPolicy.REQUIRE_OTHER_ONLY).read(file, FileType.JSON)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `read should fail when plural form value is not string`() {
+        val file = File(testProjectDir, "plural-non-string-form.json").apply {
+            writeText(
+                """
+                {
+                    "$PLURAL_KEY": {
+                        "zero": "zero value",
+                        "one": "one value",
+                        "two": "two value",
+                        "few": "few value",
+                        "many": "many value",
+                        "other": 1
+                    }
+                }
+                """.trimIndent(),
+            )
+        }
+
+        assertThrows<IllegalArgumentException> {
+            fileReader().read(file, FileType.JSON)
+        }
+    }
+
+    @Test
+    fun `read should fail when localisation value is neither string nor object`() {
+        val file = File(testProjectDir, "unsupported-value.json").apply {
+            writeText(
+                """
+                {
+                    "sample__section__value": ["unexpected"]
+                }
+                """.trimIndent(),
+            )
+        }
+
+        assertThrows<IllegalStateException> {
+            fileReader().read(file, FileType.JSON)
+        }
+    }
+
+    private fun writePluralFile(fileName: String, forms: Set<String>): File {
+        return File(testProjectDir, fileName.ifBlank { "empty.json" }).apply {
+            val formsContent = forms.joinToString(",\n") { form ->
+                "\"$form\": \"$form value\""
+            }
+            writeText(
+                """
+                {
+                    "$PLURAL_KEY": {
+                        $formsContent
+                    }
+                }
+                """.trimIndent(),
+            )
+        }
+    }
+
+    private fun pluralFormCombinations(): List<Set<String>> {
+        return (0 until (1 shl REQUIRED_PLURAL_FORMS.size)).map { mask ->
+            REQUIRED_PLURAL_FORMS
+                .filterIndexed { index, _ -> mask and (1 shl index) != 0 }
+                .toSet()
+        }
+    }
+
+    private fun fileReader(
+        pluralFormPolicy: PluralFormPolicy = PluralFormPolicy.REQUIRE_ALL_FORMS,
+    ) = FileReader(
+        pluralFormPolicy = pluralFormPolicy,
+    )
+
+    private companion object {
+        const val PLURAL_KEY = "sample__section__item_count"
+        val REQUIRED_PLURAL_FORMS = listOf("zero", "one", "two", "few", "many", "other")
     }
 }

--- a/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/FileContentGenerator.kt
+++ b/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/FileContentGenerator.kt
@@ -7,36 +7,38 @@ import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import java.io.File
 import java.nio.file.Path
-import java.util.Locale
 import kotlin.reflect.KClass
 
-class FileContentGenerator(
+public class FileContentGenerator(
     private val sourceRoot: Path,
     private val outputDirectory: Path,
-    private val fileContent: Map<String, String>,
     private val outputSuffix: String,
 ) {
-
-    fun generateFileContents(groupedMap: Map<String, Map<String, Any>>): Map<Path, String> {
+    public fun generateFileContents(groupedMap: Map<String, Node.Group>): Map<Path, String> {
         return groupedMap.map { (fileName, content) ->
-            val capitalizedFileName = fileName.replaceFirstChar {
-                if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
-            }
-
-            val rootObjectName = "$capitalizedFileName$outputSuffix"
+            val rootObjectName = "${fileName.toTypeName()}$outputSuffix"
             val filePath = outputDirectory.resolve("$rootObjectName.kt")
 
             filePath to generateFileContent(filePath, rootObjectName, content)
         }.toMap()
     }
 
-    fun generateFileContent(filePath: Path, fileName: String, root: Map<String, Any>): String {
-        return FileSpec.builder(getFilePackage(filePath), fileName)
+    public fun generateFileContent(filePath: Path, fileName: String, root: Node.Group): String {
+        val builder = FileSpec.builder(getFilePackage(filePath), fileName)
             .indent(DEFAULT_INDENT)
             .addImport(
                 "com.qinshift.linguine.linguineruntime.presentation",
                 "Localiser.localise",
             )
+
+        if (hasPluralEntries(root)) {
+            builder.addImport(
+                "com.qinshift.linguine.linguineruntime.presentation",
+                "Localiser.localisePlural",
+            )
+        }
+
+        return builder
             .addType(
                 TypeSpec.objectBuilder(fileName)
                     .addObjectContent(root)
@@ -54,81 +56,206 @@ class FileContentGenerator(
         return relativePath.ifBlank { "presentation" }
     }
 
-    private fun TypeSpec.Builder.addObjectContent(root: Map<String, Any>): TypeSpec.Builder {
-        @Suppress("UNCHECKED_CAST")
-        root.forEach { (key, value) ->
+    private fun TypeSpec.Builder.addObjectContent(root: Node.Group): TypeSpec.Builder {
+        root.children.forEach { (key, value) ->
             when (value) {
-                is Map<*, *> -> {
-                    addType(
-                        TypeSpec.objectBuilder(
-                            key.replaceFirstChar {
-                                if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString()
-                            },
-                        )
-                            .addObjectContent(value as Map<String, Any>)
-                            .build(),
-                    )
+                is Node.Group -> {
+                    val builder = TypeSpec.objectBuilder(key.toTypeName())
+                    val type = builder
+                        .addObjectContent(value)
+                        .build()
+                    addType(type)
                 }
 
-                is Pair<*, *> -> {
-                    val originalKey = value.first as String
-                    value.second as String
-                    addFunctionOrProperty(key, originalKey)
+                is Node.Item -> {
+                    addFunctionOrProperty(key, value.key, value.translation)
                 }
             }
         }
         return this
     }
 
-    private fun TypeSpec.Builder.addFunctionOrProperty(key: String, originalKey: String) {
-        val translation = fileContent[originalKey]
-        val dataTypes = determineDataTypes(translation ?: "")
-
-        if (dataTypes.isNotEmpty()) {
-            val parameters = dataTypes.mapIndexed { index, type ->
-                ParameterSpec.builder("param${index + 1}", type).build()
+    private fun TypeSpec.Builder.addFunctionOrProperty(key: String, originalKey: String, translation: Translation) {
+        when (translation) {
+            is Translation.Text -> {
+                if (hasFormatArguments(translation.value)) {
+                    addTextFunction(
+                        key = key,
+                        originalKey = originalKey,
+                        formatString = translation.value,
+                    )
+                } else {
+                    addTextProperty(key = key, originalKey = originalKey)
+                }
             }
 
-            addFunction(
-                FunSpec.builder(key)
-                    .apply {
-                        parameters.forEach { addParameter(it) }
-                    }
-                    .returns(String::class)
-                    .addStatement(
-                        """return localise("%L", ${parameters.joinToString(", ") { it.name }})""",
-                        originalKey,
-                    )
-                    .build(),
-            )
-        } else {
-            addProperty(
-                PropertySpec.builder(key, String::class)
-                    .initializer("""localise("%L")""", originalKey)
-                    .build(),
-            )
+            is Translation.Plural -> {
+                addPluralFunction(
+                    key = key,
+                    originalKey = originalKey,
+                    formatStrings = translation.forms.values,
+                )
+            }
         }
     }
 
-    private fun determineDataTypes(formatString: String): List<KClass<*>> {
-        val formatSpecifiers = FORMAT_SPECIFIER_REGEX.findAll(formatString)
-        return formatSpecifiers.map { determineDataType(it.value) }.toList()
+    private fun TypeSpec.Builder.addTextFunction(key: String, originalKey: String, formatString: String) {
+        val parameters = buildFormatParameters(formatString)
+        val spec = FunSpec.builder(key)
+            .apply { parameters.forEach(::addParameter) }
+            .returns(String::class)
+            .addStatement("""return localise(%L)""", buildFunctionArguments(originalKey, parameters))
+            .build()
+        addFunction(spec)
     }
 
-    private fun determineDataType(formatSpecifier: String): KClass<*> {
-        return when {
-            formatSpecifier.contains("\$s") -> String::class
-            formatSpecifier.contains("\$d") -> Int::class
-            formatSpecifier.contains("\$f") -> Float::class
-            formatSpecifier.contains("s") -> String::class
-            formatSpecifier.contains("d") -> Int::class
-            formatSpecifier.contains("f") -> Float::class
-            else -> Any::class
+    private fun TypeSpec.Builder.addTextProperty(key: String, originalKey: String) {
+        val spec = PropertySpec.builder(key, String::class)
+            .initializer("""localise("%L")""", originalKey)
+            .build()
+        addProperty(spec)
+    }
+
+    private fun TypeSpec.Builder.addPluralFunction(
+        key: String,
+        originalKey: String,
+        formatStrings: Collection<String>,
+    ) {
+        val parameters = buildFormatParameters(formatStrings)
+        val spec = FunSpec.builder(key)
+            .addParameter("count", Number::class)
+            .apply { parameters.forEach(::addParameter) }
+            .returns(String::class)
+            .addStatement(
+                """return localisePlural(%L)""",
+                buildFunctionArguments(originalKey, parameters, leadingArguments = listOf("count")),
+            )
+            .build()
+        addFunction(spec)
+    }
+
+    private fun buildFormatParameters(formatString: String): List<ParameterSpec> {
+        return buildFormatParameters(parseFormatSpecifiers(formatString))
+    }
+
+    private fun buildFormatParameters(formatStrings: Collection<String>): List<ParameterSpec> {
+        return buildFormatParameters(formatStrings.flatMap(::parseFormatSpecifiers))
+    }
+
+    private fun parseFormatSpecifiers(formatString: String): List<FormatSpecifier> {
+        val matches = FORMAT_SPECIFIER_REGEX.findAll(formatString).toList()
+        validateFormatSpecifiers(formatString, matches)
+        var nextSequentialIndex = 1
+
+        return matches.map { match ->
+            val explicitIndex = match.value
+                .drop(1)
+                .substringBefore('$', "")
+                .takeIf(String::isNotEmpty)
+                ?.toInt()
+            val parameterIndex = explicitIndex ?: nextSequentialIndex++
+            val specifier = match.value.lastOrNull()
+                ?: error("Expected format specifier in '${match.value}'.")
+
+            FormatSpecifier(parameterIndex, specifier)
         }
+    }
+
+    private fun buildFormatParameters(formatSpecifiers: List<FormatSpecifier>): List<ParameterSpec> {
+        validateSequentialParameterIndexes(formatSpecifiers.map(FormatSpecifier::parameterIndex))
+
+        val indexedSpecifiers = linkedMapOf<Int, Char>()
+        formatSpecifiers.forEach { formatSpecifier ->
+            indexedSpecifiers[formatSpecifier.parameterIndex] = formatSpecifier.specifier
+        }
+
+        return indexedSpecifiers.entries
+            .sortedBy { it.key }
+            .map { (index, specifier) ->
+                ParameterSpec
+                    .builder("param$index", determineParameterType(specifier))
+                    .build()
+            }
+    }
+
+    private fun validateFormatSpecifiers(
+        formatString: String,
+        matches: List<MatchResult>,
+    ) {
+        val malformedSpecifiers = MALFORMED_FORMAT_SPECIFIER_REGEX.findAll(formatString)
+            .map(MatchResult::value)
+            .toList()
+        require(malformedSpecifiers.isEmpty()) {
+            """
+                Expected format specifiers to be either unindexed or indexed with a number. 
+                Malformed: ${malformedSpecifiers.joinToString(", ")}.
+            """.trimIndent()
+        }
+
+        val hasUnindexedSpecifier = matches.any { '$' !in it.value }
+        require(matches.size <= 1 || !hasUnindexedSpecifier) {
+            """
+                Expected all format specifiers to be indexed 
+                when a string contains multiple placeholders: '$formatString'
+            """.trimIndent()
+        }
+    }
+
+    private fun validateSequentialParameterIndexes(parameterIndexes: List<Int>) {
+        val indexes = parameterIndexes.distinct().sorted()
+        if (indexes.isEmpty()) return
+
+        val expectedIndexes = (1..indexes.last()).toList()
+        val missingIndexes = expectedIndexes - indexes.toSet()
+        require(missingIndexes.isEmpty()) {
+            """
+                Expected format specifier indexes to be sequential from 1 to ${indexes.last()}. 
+                Missing: ${missingIndexes.joinToString(", ")}.
+            """.trimIndent()
+        }
+    }
+
+    private fun determineParameterType(specifier: Char): KClass<*> {
+        return when (specifier.lowercaseChar()) {
+            's', 'd', 'f' -> String::class
+            else -> error("Unsupported format specifier '%$specifier'.")
+        }
+    }
+
+    private fun buildFunctionArguments(
+        originalKey: String,
+        parameters: List<ParameterSpec>,
+        leadingArguments: List<String> = emptyList(),
+    ): String {
+        val arguments = listOf("\"$originalKey\"") + leadingArguments + parameters.map(ParameterSpec::name)
+        return arguments.joinToString(", ")
+    }
+
+    private fun hasFormatArguments(formatString: String): Boolean {
+        return FORMAT_SPECIFIER_REGEX.containsMatchIn(formatString)
+    }
+
+    private fun hasPluralEntries(root: Node.Group): Boolean {
+        return root.children.values.any { value ->
+            when (value) {
+                is Node.Group -> hasPluralEntries(value)
+                is Node.Item -> value.translation is Translation.Plural
+            }
+        }
+    }
+
+    private fun String.toTypeName(): String {
+        return replaceFirstChar(Char::titlecase)
     }
 
     private companion object {
         const val DEFAULT_INDENT = "    "
         val FORMAT_SPECIFIER_REGEX = Regex("%[0-9]*\\$?[sdf]")
+        val MALFORMED_FORMAT_SPECIFIER_REGEX = Regex("%\\$[sdf]")
     }
+
+    private data class FormatSpecifier(
+        val parameterIndex: Int,
+        val specifier: Char,
+    )
 }

--- a/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/FileParser.kt
+++ b/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/FileParser.kt
@@ -1,12 +1,20 @@
 package com.qinshift.linguine.linguinegenerator
 
-class FileParser(
-    private val fileContent: Map<String, String>,
+public class FileParser(
+    fileContent: Map<String, *>,
     private val minorDelimiter: String,
     private val majorDelimiter: String,
 ) {
-    fun generateGroupedMapStructure(): Map<String, Map<String, Any>> {
-        val groupedMap = mutableMapOf<String, MutableMap<String, Pair<String, String>>>()
+    private val fileContent: Map<String, Translation> = fileContent.mapValues { (key, value) ->
+        when (value) {
+            is Translation -> value
+            is String -> Translation.Text(value)
+            else -> error("Unsupported translation value for key '$key': $value")
+        }
+    }
+
+    public fun generateGroupedNodeStructure(): Map<String, Node.Group> {
+        val groupedMap = mutableMapOf<String, MutableMap<String, Node.Item>>()
         fileContent.forEach { (key, value) ->
             val groupName: String
             val nestedKey: String
@@ -19,19 +27,20 @@ class FileParser(
                 nestedKey = key
             }
 
-            groupedMap.computeIfAbsent(groupName) { mutableMapOf() }[nestedKey] = key to value
+            groupedMap.computeIfAbsent(groupName) { mutableMapOf() }[nestedKey] = Node.Item(
+                key = key,
+                translation = value,
+            )
         }
 
-        return groupedMap.mapValues { (_, map) -> generateNestedMapStructure(map) }
+        return groupedMap.mapValues { (_, map) -> generateNestedNodeStructure(map) }
     }
 
-    private fun generateNestedMapStructure(map: Map<String, Pair<String, String>>): Map<String, Any> {
-        val root = mutableMapOf<String, Any>()
-        map.forEach { (key, value) ->
+    private fun generateNestedNodeStructure(map: Map<String, Node.Item>): Node.Group {
+        return map.entries.fold(Node.Group(emptyMap())) { root, (key, value) ->
             val parts = transformKeyToCamelCaseSegments(key)
-            updateNestedMapStructure(root, parts, value)
+            insertLeaf(root, parts, value)
         }
-        return root
     }
 
     private fun transformKeyToCamelCaseSegments(key: String): List<String> {
@@ -42,22 +51,35 @@ class FileParser(
         }
     }
 
-    private fun updateNestedMapStructure(
-        root: MutableMap<String, Any>,
+    private fun insertLeaf(
+        root: Node.Group,
         parts: List<String>,
-        value: Pair<String, String>,
-    ) {
-        var current = root
-        @Suppress("UNCHECKED_CAST")
-        parts.forEachIndexed { index, part ->
-            val formattedPart = formatPart(part, index < parts.lastIndex)
-            if (index == parts.lastIndex) {
-                current[formattedPart] = value
-            } else {
-                current =
-                    current.computeIfAbsent(formattedPart) { mutableMapOf<String, Any>() } as MutableMap<String, Any>
-            }
+        value: Node.Item,
+        index: Int = 0,
+    ): Node.Group {
+        val formattedPart = formatPart(parts[index], index < parts.lastIndex)
+
+        if (index == parts.lastIndex) {
+            return root.copy(
+                children = root.children + (formattedPart to value),
+            )
         }
+
+        val nestedGroup = when (val existingNode = root.children[formattedPart]) {
+            null -> Node.Group(emptyMap())
+            is Node.Group -> existingNode
+            is Node.Item -> error("Expected group node but found leaf ${existingNode.key}.")
+        }
+
+        val entry = formattedPart to insertLeaf(
+            root = nestedGroup,
+            parts = parts,
+            value = value,
+            index = index + 1,
+        )
+        return root.copy(
+            children = root.children + entry,
+        )
     }
 
     private fun formatPart(part: String, isIntermediate: Boolean): String {

--- a/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/FileWriter.kt
+++ b/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/FileWriter.kt
@@ -2,8 +2,8 @@ package com.qinshift.linguine.linguinegenerator
 
 import java.io.File
 
-class FileWriter {
-    fun writeToFile(outputFile: File, outputFileContent: String) {
+public class FileWriter {
+    public fun writeToFile(outputFile: File, outputFileContent: String) {
         if (!outputFile.exists()) {
             outputFile.parentFile?.mkdirs()
             outputFile.createNewFile()

--- a/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/Linguine.kt
+++ b/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/Linguine.kt
@@ -2,13 +2,14 @@ package com.qinshift.linguine.linguinegenerator
 
 import com.qinshift.linguine.linguinegenerator.filereader.FileType
 
-open class Linguine {
-    var inputFilePath: String = ""
-    var inputFileType: FileType = FileType.JSON
-    var outputFilePath: String = ""
-    var sourceRootPath: String = ""
-    var outputSuffix: String = "Strings"
-    var majorDelimiter: String = "__"
-    var minorDelimiter: String = "_"
-    var buildTaskName: String? = null
+public open class Linguine {
+    public var inputFilePath: String = ""
+    public var inputFileType: FileType = FileType.JSON
+    public var outputFilePath: String = ""
+    public var sourceRootPath: String = ""
+    public var outputSuffix: String = "Strings"
+    public var majorDelimiter: String = "__"
+    public var minorDelimiter: String = "_"
+    public var buildTaskName: String? = null
+    public var pluralFormPolicy: PluralFormPolicy = PluralFormPolicy.REQUIRE_ALL_FORMS
 }

--- a/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/LinguinePlugin.kt
+++ b/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/LinguinePlugin.kt
@@ -24,7 +24,7 @@ import org.gradle.work.Incremental
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 
 @Suppress("unused")
-class LinguinePlugin : Plugin<Project> {
+public class LinguinePlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
         val extension = project.extensions.create("linguine", Linguine::class.java)
@@ -48,6 +48,7 @@ class LinguinePlugin : Plugin<Project> {
             sourceRootPath.set(extension.sourceRootPath)
             outputFilePath.set(extension.outputFilePath)
             outputSuffix.set(extension.outputSuffix)
+            pluralFormPolicy.set(extension.pluralFormPolicy)
         }
 
         project.afterEvaluate {
@@ -89,40 +90,43 @@ class LinguinePlugin : Plugin<Project> {
 }
 
 @CacheableTask
-abstract class GenerateStringsTask @Inject constructor(
+public abstract class GenerateStringsTask @Inject constructor(
     private val layout: ProjectLayout,
 ) : DefaultTask() {
 
     @get:Incremental
     @get:InputFile
     @get:PathSensitive(PathSensitivity.RELATIVE)
-    abstract val inputFile: RegularFileProperty
+    public abstract val inputFile: RegularFileProperty
 
     @get:Input
-    abstract val fileType: GradleProperty<LinguineFileType>
+    public abstract val fileType: GradleProperty<LinguineFileType>
 
     @get:Input
-    abstract val minorDelimiter: GradleProperty<String>
+    public abstract val minorDelimiter: GradleProperty<String>
 
     @get:Input
-    abstract val majorDelimiter: GradleProperty<String>
+    public abstract val majorDelimiter: GradleProperty<String>
 
     @get:OutputDirectory
-    abstract val outputDirectory: DirectoryProperty
+    public abstract val outputDirectory: DirectoryProperty
 
     @get:Input
-    abstract val sourceRootPath: GradleProperty<String>
+    public abstract val sourceRootPath: GradleProperty<String>
 
     @get:Input
-    abstract val outputFilePath: GradleProperty<String>
+    public abstract val outputFilePath: GradleProperty<String>
 
     @get:Input
-    abstract val outputSuffix: GradleProperty<String>
+    public abstract val outputSuffix: GradleProperty<String>
+
+    @get:Input
+    public abstract val pluralFormPolicy: GradleProperty<PluralFormPolicy>
 
     @TaskAction
-    fun generate() {
+    public fun generate() {
         // Read input file
-        val fileContent = FileReader().read(
+        val fileContent = FileReader(pluralFormPolicy.get()).read(
             file = inputFile.asFile.get(),
             fileType = fileType.get(),
         )
@@ -134,7 +138,7 @@ abstract class GenerateStringsTask @Inject constructor(
             majorDelimiter = majorDelimiter.get(),
         )
 
-        val groupedMap = fileParser.generateGroupedMapStructure()
+        val groupedMap = fileParser.generateGroupedNodeStructure()
 
         val resolvedOutputPath = outputDirectory.get().asFile.toPath()
 
@@ -154,7 +158,6 @@ abstract class GenerateStringsTask @Inject constructor(
         val fileContentGenerator = FileContentGenerator(
             sourceRoot = resolvedSourceRoot,
             outputDirectory = resolvedOutputPath,
-            fileContent = fileContent,
             outputSuffix = outputSuffix.get()
         )
 
@@ -166,8 +169,7 @@ abstract class GenerateStringsTask @Inject constructor(
             fileWriter.writeToFile(filePath.toFile(), content)
 
             logger.info(
-                "Linguine: File ${filePath.fileName} " +
-                    "has been successfully created in the directory ${filePath.parent}",
+                "Linguine: File ${filePath.fileName} has been successfully created in the directory ${filePath.parent}"
             )
         }
     }

--- a/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/Node.kt
+++ b/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/Node.kt
@@ -1,0 +1,6 @@
+package com.qinshift.linguine.linguinegenerator
+
+public sealed interface Node {
+    public data class Group(val children: Map<String, Node>) : Node
+    public data class Item(val key: String, val translation: Translation) : Node
+}

--- a/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/PluralFormPolicy.kt
+++ b/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/PluralFormPolicy.kt
@@ -1,0 +1,8 @@
+package com.qinshift.linguine.linguinegenerator
+
+public enum class PluralFormPolicy(
+    internal val requiredForms: List<String>,
+) {
+    REQUIRE_ALL_FORMS(listOf("zero", "one", "two", "few", "many", "other")),
+    REQUIRE_OTHER_ONLY(listOf("other"))
+}

--- a/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/Translation.kt
+++ b/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/Translation.kt
@@ -1,0 +1,6 @@
+package com.qinshift.linguine.linguinegenerator
+
+public sealed interface Translation {
+    public data class Text(val value: String) : Translation
+    public data class Plural(val forms: Map<String, String>) : Translation
+}

--- a/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/filereader/FileReader.kt
+++ b/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/filereader/FileReader.kt
@@ -1,18 +1,63 @@
 package com.qinshift.linguine.linguinegenerator.filereader
 
-import com.google.gson.Gson
-import com.google.gson.reflect.TypeToken
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import com.qinshift.linguine.linguinegenerator.PluralFormPolicy
+import com.qinshift.linguine.linguinegenerator.Translation
 import java.io.File
 
-class FileReader {
-    fun read(file: File, fileType: FileType): Map<String, String> {
+public class FileReader(
+    private val pluralFormPolicy: PluralFormPolicy,
+) {
+    public fun read(file: File, fileType: FileType): Map<String, Translation> {
         return when (fileType) {
             FileType.JSON -> parseJSON(file.readText())
         }
     }
 
-    private fun parseJSON(fileContent: String): Map<String, String> {
-        val type = object : TypeToken<Map<String, String>>() {}.type
-        return Gson().fromJson(fileContent, type)
+    private fun parseJSON(fileContent: String): Map<String, Translation> {
+        val root = JsonParser.parseString(fileContent)
+        require(root.isJsonObject) { "Expected root JSON object for localisation file." }
+
+        return root.asJsonObject.entrySet().associate { (key, value) ->
+            key to parseValue(key, value)
+        }
+    }
+
+    private fun parseValue(key: String, value: JsonElement): Translation {
+        return when {
+            value.isJsonPrimitive && value.asJsonPrimitive.isString -> {
+                Translation.Text(value.asString)
+            }
+
+            value.isJsonObject -> {
+                Translation.Plural(parsePluralForms(key, value.asJsonObject))
+            }
+
+            else -> {
+                error("Expected string or object for key '$key' but was $value")
+            }
+        }
+    }
+
+    private fun parsePluralForms(key: String, value: JsonObject): Map<String, String> {
+        val forms = value.entrySet().associate { (formKey, formValue) ->
+            require(formValue.isJsonPrimitive && formValue.asJsonPrimitive.isString) {
+                "Expected plural form '$formKey' of key '$key' to be a string."
+            }
+            formKey to formValue.asString
+        }
+
+        val missingForms = pluralFormPolicy.requiredForms.filterNot(forms::containsKey)
+        require(missingForms.isEmpty()) {
+            """
+                Expected plural key '$key' to contain required forms: 
+                ${pluralFormPolicy.requiredForms.joinToString(", ")}. 
+                Missing: ${missingForms.joinToString(", ")}.
+            """.trimIndent()
+        }
+
+        return forms
     }
 }

--- a/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/filereader/FileType.kt
+++ b/linguine-generator/src/main/kotlin/com/qinshift/linguine/linguinegenerator/filereader/FileType.kt
@@ -1,5 +1,5 @@
 package com.qinshift.linguine.linguinegenerator.filereader
 
-enum class FileType {
+public enum class FileType {
     JSON
 }

--- a/linguine-generator/src/test/kotlin/com/qinshift/linguine/linguinegenerator/LinguinePluginTest.kt
+++ b/linguine-generator/src/test/kotlin/com/qinshift/linguine/linguinegenerator/LinguinePluginTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 
-class LinguinePluginTest {
+internal class LinguinePluginTest {
 
     @Test
     fun `plugin registers a task`() {

--- a/linguine-runtime/build.gradle.kts
+++ b/linguine-runtime/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 }
 
 kotlin {
+    explicitApi()
     iosX64 {
         binaries {
             framework {
@@ -34,6 +35,9 @@ kotlin {
         commonMain.dependencies {
             implementation(libs.kotlinx.serialization.json)
             implementation(libs.kermit)
+        }
+        commonTest.dependencies {
+            implementation(kotlin("test"))
         }
     }
 }

--- a/linguine-runtime/src/commonMain/kotlin/com/qinshift/linguine/linguineruntime/presentation/Language.kt
+++ b/linguine-runtime/src/commonMain/kotlin/com/qinshift/linguine/linguineruntime/presentation/Language.kt
@@ -1,3 +1,6 @@
 package com.qinshift.linguine.linguineruntime.presentation
 
-internal data class Language(val code: String)
+import kotlin.jvm.JvmInline
+
+@JvmInline
+internal value class Language(val code: String)

--- a/linguine-runtime/src/commonMain/kotlin/com/qinshift/linguine/linguineruntime/presentation/LanguagePluralForm.kt
+++ b/linguine-runtime/src/commonMain/kotlin/com/qinshift/linguine/linguineruntime/presentation/LanguagePluralForm.kt
@@ -1,0 +1,10 @@
+package com.qinshift.linguine.linguineruntime.presentation
+
+internal enum class LanguagePluralForm(val key: String) {
+    ZERO("zero"),
+    ONE("one"),
+    TWO("two"),
+    FEW("few"),
+    MANY("many"),
+    OTHER("other"),
+}

--- a/linguine-runtime/src/commonMain/kotlin/com/qinshift/linguine/linguineruntime/presentation/LanguagePluralRules.kt
+++ b/linguine-runtime/src/commonMain/kotlin/com/qinshift/linguine/linguineruntime/presentation/LanguagePluralRules.kt
@@ -1,0 +1,96 @@
+package com.qinshift.linguine.linguineruntime.presentation
+
+import kotlin.math.abs
+
+// some of the rules can be found here: https://localizely.com/language-plural-rules/
+internal object LanguagePluralRules {
+
+    fun select(language: Language, count: Number): List<LanguagePluralForm> {
+        val absoluteCount = abs(count.toDouble())
+        require(absoluteCount.isFinite()) { "Plural count must be finite." }
+
+        return when (LanguagePluralSupported.fromCode(language.code)) {
+            LanguagePluralSupported.CZECH -> selectCzech(absoluteCount)
+            LanguagePluralSupported.ENGLISH -> selectEnglish(absoluteCount)
+            LanguagePluralSupported.SPANISH -> selectSpanish(absoluteCount)
+            LanguagePluralSupported.FRENCH -> selectFrench(absoluteCount)
+            LanguagePluralSupported.SLOVAK -> selectSlovak(absoluteCount)
+            else -> error(
+                """
+                    Plural rules for language '${language.code}' are not implemented in Linguine. 
+                    Add the language-specific plural rules to the plugin/runtime 
+                    before using plural localisations for this language.
+                """.trimIndent(),
+            )
+        }
+    }
+
+    private fun selectEnglish(count: Double): List<LanguagePluralForm> {
+        return when {
+            count.isWholeNumber(0L) -> listOf(LanguagePluralForm.ZERO, LanguagePluralForm.OTHER)
+            count.isWholeNumber(1L) -> listOf(LanguagePluralForm.ONE)
+            count.isWholeNumber(2L) -> listOf(LanguagePluralForm.TWO, LanguagePluralForm.OTHER)
+            else -> listOf(LanguagePluralForm.OTHER)
+        }
+    }
+
+    @Suppress("MagicNumber")
+    private fun selectCzech(count: Double): List<LanguagePluralForm> {
+        return when {
+            count.isWholeNumber(0L) -> listOf(LanguagePluralForm.ZERO, LanguagePluralForm.OTHER)
+            count.hasNonZeroFraction() -> listOf(LanguagePluralForm.MANY)
+            count.isWholeNumber(1L) -> listOf(LanguagePluralForm.ONE)
+            count.isWholeNumber(2L) -> listOf(LanguagePluralForm.TWO, LanguagePluralForm.FEW)
+            count.toLong() in 3L..4L -> listOf(LanguagePluralForm.FEW)
+            else -> listOf(LanguagePluralForm.OTHER)
+        }
+    }
+
+    @Suppress("MagicNumber")
+    private fun selectSlovak(count: Double): List<LanguagePluralForm> {
+        return when {
+            count.isWholeNumber(0L) -> listOf(LanguagePluralForm.ZERO, LanguagePluralForm.OTHER)
+            count.hasNonZeroFraction() -> listOf(LanguagePluralForm.MANY)
+            count.isWholeNumber(1L) -> listOf(LanguagePluralForm.ONE)
+            count.isWholeNumber(2L) -> listOf(LanguagePluralForm.TWO, LanguagePluralForm.FEW)
+            count in 3.0..4.0 -> listOf(LanguagePluralForm.FEW)
+            else -> listOf(LanguagePluralForm.OTHER)
+        }
+    }
+
+    @Suppress("MagicNumber")
+    private fun selectFrench(count: Double): List<LanguagePluralForm> {
+        return when {
+            count.isWholeNumber(0L) -> listOf(LanguagePluralForm.ZERO, LanguagePluralForm.ONE)
+            count in 0.0..<2.0 -> listOf(LanguagePluralForm.ONE)
+            count.isWholeNumber(2L) -> listOf(LanguagePluralForm.TWO, LanguagePluralForm.OTHER)
+            count.isWholeMillion() -> listOf(LanguagePluralForm.MANY)
+            else -> listOf(LanguagePluralForm.OTHER)
+        }
+    }
+
+    @Suppress("MagicNumber")
+    private fun selectSpanish(count: Double): List<LanguagePluralForm> {
+        return when {
+            count.isWholeNumber(0L) -> listOf(LanguagePluralForm.ZERO, LanguagePluralForm.OTHER)
+            count.isWholeNumber(1L) -> listOf(LanguagePluralForm.ONE)
+            count.isWholeNumber(2L) -> listOf(LanguagePluralForm.TWO, LanguagePluralForm.OTHER)
+            count.isWholeMillion() -> listOf(LanguagePluralForm.MANY)
+            else -> listOf(LanguagePluralForm.OTHER)
+        }
+    }
+
+    private fun Double.isWholeNumber(expectedValue: Long): Boolean {
+        return hasNonZeroFraction().not() && this.toLong() == expectedValue
+    }
+
+    @Suppress("MagicNumber")
+    private fun Double.hasNonZeroFraction(): Boolean {
+        return this % 1.0 != 0.0
+    }
+
+    @Suppress("MagicNumber")
+    private fun Double.isWholeMillion(): Boolean {
+        return hasNonZeroFraction().not() && this.toLong() != 0L && this.toLong() % 1_000_000L == 0L
+    }
+}

--- a/linguine-runtime/src/commonMain/kotlin/com/qinshift/linguine/linguineruntime/presentation/LanguagePluralSupported.kt
+++ b/linguine-runtime/src/commonMain/kotlin/com/qinshift/linguine/linguineruntime/presentation/LanguagePluralSupported.kt
@@ -1,0 +1,16 @@
+package com.qinshift.linguine.linguineruntime.presentation
+
+internal enum class LanguagePluralSupported(val code: String) {
+    CZECH("cs"),
+    ENGLISH("en"),
+    FRENCH("fr"),
+    SLOVAK("sk"),
+    SPANISH("es");
+
+    companion object {
+        private val byCode = entries.associateBy(LanguagePluralSupported::code)
+        val supportedCodes: String = entries.joinToString(", ") { it.code }
+
+        fun fromCode(code: String): LanguagePluralSupported? = byCode[code.lowercase()]
+    }
+}

--- a/linguine-runtime/src/commonMain/kotlin/com/qinshift/linguine/linguineruntime/presentation/Localisation.kt
+++ b/linguine-runtime/src/commonMain/kotlin/com/qinshift/linguine/linguineruntime/presentation/Localisation.kt
@@ -6,21 +6,55 @@ internal interface Localisation {
 
     fun get(key: String, vararg args: String): String?
 
+    fun getPlural(key: String, count: Number, vararg args: String): String?
+
     object Empty : Localisation {
         override fun get(key: String, vararg args: String): String? = null
+        override fun getPlural(key: String, count: Number, vararg args: String): String? = null
     }
 
     object KeyBased : Localisation {
         override fun get(key: String, vararg args: String) = key.also {
             Logger.w { "No localisation found for $key" }
         }
+
+        override fun getPlural(key: String, count: Number, vararg args: String) = key.also {
+            Logger.w { "No plural localisation found for $key" }
+        }
     }
 
-    data class MapBased(private val map: Map<String, String>) : Localisation {
+    data class MapBased(
+        private val language: Language,
+        private val map: Map<String, LocalisationValue>,
+    ) : Localisation {
         override fun get(key: String, vararg args: String): String? {
-            return args.foldIndexed(map[key]) { index, acc, argument ->
-                acc?.replace("%${index + 1}\$s", argument)
+            val value = map[key] as? LocalisationValue.Text ?: return null
+            return format(value.value, args.toList())
+        }
+
+        override fun getPlural(key: String, count: Number, vararg args: String): String? {
+            val value = map[key] as? LocalisationValue.Plural ?: return null
+            val selectedForms = LanguagePluralRules.select(language, count)
+            val template = value.forms.resolvePluralForm(selectedForms)
+                ?: return null
+
+            return format(template, args.toList())
+        }
+
+        private fun format(template: String, args: List<String>): String {
+            var nextUnindexedArgument = 0
+            return FORMAT_SPECIFIER_REGEX.replace(template) { match ->
+                val explicitIndex = match.groupValues[1]
+                    .takeIf(String::isNotEmpty)
+                    ?.toInt()
+                val argumentIndex = explicitIndex?.dec() ?: nextUnindexedArgument++
+
+                args.getOrNull(argumentIndex) ?: match.value
             }
+        }
+
+        private companion object {
+            val FORMAT_SPECIFIER_REGEX = Regex("%(?:([0-9]+)\\$)?[sdf]")
         }
     }
 }

--- a/linguine-runtime/src/commonMain/kotlin/com/qinshift/linguine/linguineruntime/presentation/LocalisationForms.kt
+++ b/linguine-runtime/src/commonMain/kotlin/com/qinshift/linguine/linguineruntime/presentation/LocalisationForms.kt
@@ -1,0 +1,11 @@
+package com.qinshift.linguine.linguineruntime.presentation
+
+import kotlin.jvm.JvmInline
+
+@JvmInline
+internal value class LocalisationForms(internal val values: Map<String, String>) {
+    internal fun resolvePluralForm(selectedForms: List<LanguagePluralForm>): String? {
+        return selectedForms.firstNotNullOfOrNull { form -> this.values[form.key] }
+            ?: this.values[LanguagePluralForm.OTHER.key]
+    }
+}

--- a/linguine-runtime/src/commonMain/kotlin/com/qinshift/linguine/linguineruntime/presentation/LocalisationProvider.kt
+++ b/linguine-runtime/src/commonMain/kotlin/com/qinshift/linguine/linguineruntime/presentation/LocalisationProvider.kt
@@ -4,39 +4,138 @@ import co.touchlab.kermit.Logger
 import kotlin.native.concurrent.ThreadLocal
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 @ThreadLocal
 internal object LocalisationProvider {
 
-    val default: Localisation by lazy { provide(localization = null) }
+    private const val DEFAULT_LANGUAGE_CODE = "en"
 
-    private var cachedLanguage: Language? = null
-    private var cachedLocalisation: Localisation = Localisation.Empty
+    private var defaultLanguage: Language = Language(DEFAULT_LANGUAGE_CODE)
+    private var isDefaultLanguageExplicitlySet: Boolean = false
+    private var hasWarnedAboutImplicitDefaultLanguage: Boolean = false
+    private var cachedSystemLanguage: Language? = null
+    private var cachedSystemLocalisation: Localisation = Localisation.Empty
+    private var cachedDefaultLanguage: Language? = null
+    private var cachedDefaultLocalisation: Localisation = Localisation.Empty
 
-    fun system(): Localisation {
-        val currentLanguage = LanguageRepository.load()
-        return if (currentLanguage == cachedLanguage) {
-            cachedLocalisation
+    fun configureDefaultLanguage(code: String) {
+        require(code.isNotBlank()) {
+            "Default localization language code must not be blank."
+        }
+
+        val language = Language(code.trim().lowercase())
+        isDefaultLanguageExplicitlySet = true
+        hasWarnedAboutImplicitDefaultLanguage = false
+        if (language == defaultLanguage) return
+        defaultLanguage = language
+        cachedDefaultLanguage = null
+        cachedDefaultLocalisation = Localisation.Empty
+    }
+
+    fun system(language: Language): Localisation {
+        return if (language == cachedSystemLanguage) {
+            cachedSystemLocalisation
         } else {
-            cachedLanguage = currentLanguage
-            cachedLocalisation = provide(localization = currentLanguage)
-            cachedLocalisation
+            provideAndCacheSystem(language)
         }
     }
 
-    private fun provide(localization: Language?) =
-        LocalisationRetriever.getJson(localization = localization)
-            .parse()
+    fun default(): Localisation {
+        return if (defaultLanguage == cachedDefaultLanguage) {
+            cachedDefaultLocalisation
+        } else {
+            provideAndCacheDefault()
+        }
+    }
 
-    private fun String?.parse(): Localisation {
+    private fun provideAndCacheSystem(language: Language): Localisation {
+        // Order is critical: provide() must succeed before cache keys are updated.
+        // Updating the language first creates a stale cache entry after parsing failures.
+        val localisation = provide(language)
+        cachedSystemLanguage = language
+        cachedSystemLocalisation = localisation
+        return localisation
+    }
+
+    private fun provideAndCacheDefault(): Localisation {
+        // Order is critical: provide() must succeed before cache keys are updated.
+        // Updating the language first creates a stale cache entry after parsing failures.
+        val localisation = provide(
+            localization = null,
+            resolvedLanguage = defaultLanguage,
+        )
+        cachedDefaultLanguage = defaultLanguage
+        cachedDefaultLocalisation = localisation
+        return localisation
+    }
+
+    private fun provide(localization: Language) =
+        provide(localization = localization, resolvedLanguage = localization)
+
+    private fun provide(localization: Language?, resolvedLanguage: Language): Localisation {
+        if (localization == null && !isDefaultLanguageExplicitlySet && !hasWarnedAboutImplicitDefaultLanguage) {
+            Logger.w {
+                """
+                    Linguine default localization language was not configured explicitly. 
+                    The fallback file strings.json will be interpreted as English ('en'). 
+                    If your fallback/source localization uses a different language, 
+                    call Localiser.configureDefaultLocalization("<language-code>") during application startup. 
+                    Currently supported languages are: ${LanguagePluralSupported.supportedCodes}.
+                """.trimIndent()
+            }
+            hasWarnedAboutImplicitDefaultLanguage = true
+        }
+
+        return LocalisationRetriever.getJson(localization = localization)
+            .parse(resolvedLanguage)
+    }
+
+    @Suppress("StringLiteralDuplication", "ReturnCount")
+    private fun String?.parse(language: Language): Localisation {
         return if (this == null) {
             Localisation.Empty
         } else {
             try {
-                Json.decodeFromString<Map<String, String>>(this).let(Localisation::MapBased)
+                val parsed = Json.parseToJsonElement(this)
+                    .jsonObject
+                    .mapValues { (key, value) -> parseValue(key, value) }
+
+                Localisation.MapBased(language = language, map = parsed)
             } catch (exception: SerializationException) {
                 Logger.e(exception) { "Parsing of the localisation JSON failed." }
                 return Localisation.Empty
+            }
+        }
+    }
+
+    private fun parseValue(key: String, value: JsonElement): LocalisationValue {
+        return when (value) {
+            is JsonPrimitive -> {
+                require(value.isString) { "Expected localisation value for key '$key' to be a string." }
+                LocalisationValue.Text(value.content)
+            }
+
+            is JsonObject -> {
+                val forms = value.mapValues { (pluralKey, pluralValue) ->
+                    val primitive = pluralValue.jsonPrimitive
+                    require(primitive.isString) {
+                        "Expected plural form '$pluralKey' of key '$key' to be a string."
+                    }
+                    primitive.content
+                }
+                require(LanguagePluralForm.OTHER.key in forms) {
+                    "Expected plural localisation value for key '$key' to contain required fallback form 'other'."
+                }
+                LocalisationValue.Plural(LocalisationForms(forms))
+            }
+
+            else -> {
+                error("Expected localisation value for key '$key' to be a string or object.")
             }
         }
     }

--- a/linguine-runtime/src/commonMain/kotlin/com/qinshift/linguine/linguineruntime/presentation/LocalisationValue.kt
+++ b/linguine-runtime/src/commonMain/kotlin/com/qinshift/linguine/linguineruntime/presentation/LocalisationValue.kt
@@ -1,0 +1,6 @@
+package com.qinshift.linguine.linguineruntime.presentation
+
+internal sealed interface LocalisationValue {
+    data class Text(val value: String) : LocalisationValue
+    data class Plural(val forms: LocalisationForms) : LocalisationValue
+}

--- a/linguine-runtime/src/commonMain/kotlin/com/qinshift/linguine/linguineruntime/presentation/Localiser.kt
+++ b/linguine-runtime/src/commonMain/kotlin/com/qinshift/linguine/linguineruntime/presentation/Localiser.kt
@@ -1,11 +1,23 @@
 package com.qinshift.linguine.linguineruntime.presentation
 
 @Suppress("unused")
-object Localiser {
+public object Localiser {
 
-    fun localise(key: String, vararg args: String): String {
-        return LocalisationProvider.system().get(key, *args)
-            ?: LocalisationProvider.default.get(key, *args)
+    public fun configureDefaultLocalization(languageCode: String) {
+        LocalisationProvider.configureDefaultLanguage(languageCode)
+    }
+
+    public fun localise(key: String, vararg args: String): String {
+        val currentLanguage = LanguageRepository.load()
+        return LocalisationProvider.system(currentLanguage).get(key, *args)
+            ?: LocalisationProvider.default().get(key, *args)
             ?: Localisation.KeyBased.get(key, *args)
+    }
+
+    public fun localisePlural(key: String, count: Number, vararg args: String): String {
+        val currentLanguage = LanguageRepository.load()
+        return LocalisationProvider.system(currentLanguage).getPlural(key, count, *args)
+            ?: LocalisationProvider.default().getPlural(key, count, *args)
+            ?: Localisation.KeyBased.getPlural(key, count, *args)
     }
 }

--- a/linguine-runtime/src/commonTest/kotlin/com/qinshift/linguine/linguineruntime/presentation/LocalisationTest.kt
+++ b/linguine-runtime/src/commonTest/kotlin/com/qinshift/linguine/linguineruntime/presentation/LocalisationTest.kt
@@ -1,0 +1,73 @@
+package com.qinshift.linguine.linguineruntime.presentation
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LocalisationTest {
+
+    @Test
+    fun `text localisation formats single unindexed placeholder`() {
+        val localisation = Localisation.MapBased(
+            language = Language("en"),
+            map = mapOf(
+                "sample__section__label" to LocalisationValue.Text("Value %s"),
+            ),
+        )
+
+        val result = localisation.get("sample__section__label", "Sample")
+
+        assertEquals("Value Sample", result)
+    }
+
+    @Test
+    fun `text localisation formats indexed placeholders without reprocessing inserted arguments`() {
+        val localisation = Localisation.MapBased(
+            language = Language("en"),
+            map = mapOf(
+                "sample__section__label" to LocalisationValue.Text("%1\$s and %2\$s"),
+            ),
+        )
+
+        val result = localisation.get("sample__section__label", "%2\$s", "Sample")
+
+        assertEquals("%2\$s and Sample", result)
+    }
+
+    @Test
+    fun `text localisation formats indexed placeholders in reversed order`() {
+        val localisation = Localisation.MapBased(
+            language = Language("en"),
+            map = mapOf(
+                "sample__section__label" to LocalisationValue.Text("%2\$s and %1\$s"),
+            ),
+        )
+
+        val result = localisation.get("sample__section__label", "First", "Second")
+
+        assertEquals("Second and First", result)
+    }
+
+    @Test
+    fun `plural localisation formats count and extra args`() {
+        val localisation = Localisation.MapBased(
+            language = Language("en"),
+            map = mapOf(
+                "sample__section__item_count" to LocalisationValue.Plural(
+                    LocalisationForms(
+                        mapOf(
+                            "zero" to "%1\$d items-zero for %2\$s",
+                            "one" to "%1\$d item for %2\$s",
+                            "few" to "%1\$d items-few for %2\$s",
+                            "many" to "%1\$d items-many for %2\$s",
+                            "other" to "%1\$d items for %2\$s",
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        val result = localisation.getPlural("sample__section__item_count", 3, "3", "Sample User")
+
+        assertEquals("3 items for Sample User", result)
+    }
+}

--- a/linguine-runtime/src/commonTest/kotlin/com/qinshift/linguine/linguineruntime/presentation/PluralRulesTest.kt
+++ b/linguine-runtime/src/commonTest/kotlin/com/qinshift/linguine/linguineruntime/presentation/PluralRulesTest.kt
@@ -1,0 +1,146 @@
+package com.qinshift.linguine.linguineruntime.presentation
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class PluralRulesTest {
+
+    @Test
+    fun `select chooses english forms`() {
+        assertEquals(listOf(LanguagePluralForm.ZERO, LanguagePluralForm.OTHER), LanguagePluralRules.select(Language("en"), 0))
+        assertEquals(listOf(LanguagePluralForm.ONE), LanguagePluralRules.select(Language("en"), 1))
+        assertEquals(listOf(LanguagePluralForm.TWO, LanguagePluralForm.OTHER), LanguagePluralRules.select(Language("en"), 2))
+        assertEquals(listOf(LanguagePluralForm.ZERO, LanguagePluralForm.OTHER), LanguagePluralRules.select(Language("en"), 0.0))
+        assertEquals(listOf(LanguagePluralForm.ONE), LanguagePluralRules.select(Language("en"), 1.0))
+        assertEquals(listOf(LanguagePluralForm.OTHER), LanguagePluralRules.select(Language("en"), 1.5))
+    }
+
+    @Test
+    fun `select chooses czech forms`() {
+        assertEquals(listOf(LanguagePluralForm.ZERO, LanguagePluralForm.OTHER), LanguagePluralRules.select(Language("cs"), 0))
+        assertEquals(listOf(LanguagePluralForm.ONE), LanguagePluralRules.select(Language("cs"), 1))
+        assertEquals(listOf(LanguagePluralForm.TWO, LanguagePluralForm.FEW), LanguagePluralRules.select(Language("cs"), 2))
+        assertEquals(listOf(LanguagePluralForm.FEW), LanguagePluralRules.select(Language("cs"), 3))
+        assertEquals(listOf(LanguagePluralForm.FEW), LanguagePluralRules.select(Language("cs"), 4))
+        assertEquals(listOf(LanguagePluralForm.OTHER), LanguagePluralRules.select(Language("cs"), 5))
+        assertEquals(listOf(LanguagePluralForm.ZERO, LanguagePluralForm.OTHER), LanguagePluralRules.select(Language("cs"), 0.0))
+        assertEquals(listOf(LanguagePluralForm.ONE), LanguagePluralRules.select(Language("cs"), 1.0))
+        assertEquals(listOf(LanguagePluralForm.OTHER), LanguagePluralRules.select(Language("cs"), 10.0))
+        assertEquals(listOf(LanguagePluralForm.MANY), LanguagePluralRules.select(Language("cs"), 1.5))
+        assertEquals(listOf(LanguagePluralForm.MANY), LanguagePluralRules.select(Language("cs"), 0.5))
+    }
+
+    @Test
+    fun `select chooses slovak forms`() {
+        assertEquals(listOf(LanguagePluralForm.ZERO, LanguagePluralForm.OTHER), LanguagePluralRules.select(Language("sk"), 0))
+        assertEquals(listOf(LanguagePluralForm.ONE), LanguagePluralRules.select(Language("sk"), 1))
+        assertEquals(listOf(LanguagePluralForm.TWO, LanguagePluralForm.FEW), LanguagePluralRules.select(Language("sk"), 2))
+        assertEquals(listOf(LanguagePluralForm.FEW), LanguagePluralRules.select(Language("sk"), 3))
+        assertEquals(listOf(LanguagePluralForm.FEW), LanguagePluralRules.select(Language("sk"), 4))
+        assertEquals(listOf(LanguagePluralForm.OTHER), LanguagePluralRules.select(Language("sk"), 5))
+        assertEquals(listOf(LanguagePluralForm.ZERO, LanguagePluralForm.OTHER), LanguagePluralRules.select(Language("sk"), 0.0))
+        assertEquals(listOf(LanguagePluralForm.ONE), LanguagePluralRules.select(Language("sk"), 1.0))
+        assertEquals(listOf(LanguagePluralForm.OTHER), LanguagePluralRules.select(Language("sk"), 10.0))
+        assertEquals(listOf(LanguagePluralForm.MANY), LanguagePluralRules.select(Language("sk"), 1.5))
+        assertEquals(listOf(LanguagePluralForm.MANY), LanguagePluralRules.select(Language("sk"), 0.5))
+    }
+
+    @Test
+    fun `select chooses french forms`() {
+        assertEquals(listOf(LanguagePluralForm.ZERO, LanguagePluralForm.ONE), LanguagePluralRules.select(Language("fr"), 0))
+        assertEquals(listOf(LanguagePluralForm.ONE), LanguagePluralRules.select(Language("fr"), 1))
+        assertEquals(listOf(LanguagePluralForm.ZERO, LanguagePluralForm.ONE), LanguagePluralRules.select(Language("fr"), 0.0))
+        assertEquals(listOf(LanguagePluralForm.ONE), LanguagePluralRules.select(Language("fr"), 1.0))
+        assertEquals(listOf(LanguagePluralForm.ONE), LanguagePluralRules.select(Language("fr"), 1.5))
+        assertEquals(listOf(LanguagePluralForm.TWO, LanguagePluralForm.OTHER), LanguagePluralRules.select(Language("fr"), 2))
+        assertEquals(listOf(LanguagePluralForm.TWO, LanguagePluralForm.OTHER), LanguagePluralRules.select(Language("fr"), 2.0))
+        assertEquals(listOf(LanguagePluralForm.MANY), LanguagePluralRules.select(Language("fr"), 1_000_000))
+    }
+
+    @Test
+    fun `select chooses spanish forms`() {
+        assertEquals(listOf(LanguagePluralForm.ZERO, LanguagePluralForm.OTHER), LanguagePluralRules.select(Language("es"), 0))
+        assertEquals(listOf(LanguagePluralForm.ONE), LanguagePluralRules.select(Language("es"), 1))
+        assertEquals(listOf(LanguagePluralForm.TWO, LanguagePluralForm.OTHER), LanguagePluralRules.select(Language("es"), 2))
+        assertEquals(listOf(LanguagePluralForm.ZERO, LanguagePluralForm.OTHER), LanguagePluralRules.select(Language("es"), 0.0))
+        assertEquals(listOf(LanguagePluralForm.ONE), LanguagePluralRules.select(Language("es"), 1.0))
+        assertEquals(listOf(LanguagePluralForm.OTHER), LanguagePluralRules.select(Language("es"), 1.5))
+        assertEquals(listOf(LanguagePluralForm.MANY), LanguagePluralRules.select(Language("es"), 1_000_000))
+    }
+
+    @Test
+    fun `select uses absolute value for negative counts`() {
+        assertEquals(listOf(LanguagePluralForm.ONE), LanguagePluralRules.select(Language("en"), -1))
+        assertEquals(listOf(LanguagePluralForm.TWO, LanguagePluralForm.FEW), LanguagePluralRules.select(Language("cs"), -2))
+        assertEquals(listOf(LanguagePluralForm.FEW), LanguagePluralRules.select(Language("sk"), -4))
+        assertEquals(listOf(LanguagePluralForm.MANY), LanguagePluralRules.select(Language("cs"), -1.5))
+    }
+
+    @Test
+    fun `select fails for non finite count`() {
+        assertFailsWith<IllegalArgumentException> {
+            LanguagePluralRules.select(Language("en"), Double.NaN)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LanguagePluralRules.select(Language("en"), Double.POSITIVE_INFINITY)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LanguagePluralRules.select(Language("en"), Double.NEGATIVE_INFINITY)
+        }
+    }
+
+    @Test
+    fun `resolvePluralForm falls back to other when selected form is missing`() {
+        val forms = mapOf(
+            "one" to "%1\$s item",
+            "other" to "%1\$s items",
+        )
+        val localisationForms = LocalisationForms(forms)
+        assertEquals("%1\$s items", localisationForms.resolvePluralForm(listOf(LanguagePluralForm.FEW)))
+    }
+
+    @Test
+    fun `resolvePluralForm can return any unicode plural form when present`() {
+        val forms = mapOf(
+            "zero" to "zero form",
+            "other" to "other form",
+            "two" to "two form",
+            "many" to "many form",
+        )
+        val localisationForms = LocalisationForms(forms)
+        assertEquals("zero form", localisationForms.resolvePluralForm(listOf(LanguagePluralForm.ZERO)))
+        assertEquals("two form", localisationForms.resolvePluralForm(listOf(LanguagePluralForm.TWO)))
+        assertEquals("many form", localisationForms.resolvePluralForm(listOf(LanguagePluralForm.MANY)))
+    }
+
+    @Test
+    fun `resolvePluralForm uses first available selected form`() {
+        val forms = mapOf(
+            "one" to "one form",
+            "other" to "other form",
+        )
+        val localisationForms = LocalisationForms(forms)
+        assertEquals(
+            "one form",
+            localisationForms.resolvePluralForm(listOf(LanguagePluralForm.ZERO, LanguagePluralForm.ONE)),
+        )
+    }
+
+    @Test
+    fun `resolvePluralForm returns null when other fallback is missing`() {
+        val forms = mapOf(
+            "one" to "one form",
+            "few" to "few form",
+        )
+        val localisationForms = LocalisationForms(forms)
+        assertEquals(null, localisationForms.resolvePluralForm(listOf(LanguagePluralForm.MANY)))
+    }
+
+    @Test
+    fun `select fails for unsupported language`() {
+        assertFailsWith<IllegalStateException> {
+            LanguagePluralRules.select(Language("de"), 2)
+        }
+    }
+}

--- a/linguine-runtime/src/jvmTest/kotlin/com/qinshift/linguine/linguineruntime/presentation/LocaliserJvmTest.kt
+++ b/linguine-runtime/src/jvmTest/kotlin/com/qinshift/linguine/linguineruntime/presentation/LocaliserJvmTest.kt
@@ -1,0 +1,80 @@
+package com.qinshift.linguine.linguineruntime.presentation
+
+import java.util.Locale
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class LocaliserJvmTest {
+
+    @Test
+    fun `fallback strings json uses explicitly configured default localization language`() {
+        val previousLocale = Locale.getDefault()
+
+        try {
+            Locale.setDefault(Locale.forLanguageTag("de"))
+            Localiser.configureDefaultLocalization("cs")
+
+            val result = Localiser.localisePlural("sample__section__item_count", 2, "2")
+
+            assertEquals("2 items-two", result)
+        } finally {
+            Locale.setDefault(previousLocale)
+            Localiser.configureDefaultLocalization("en")
+        }
+    }
+
+    @Test
+    fun `fallback strings json accepts plural object with other only and falls back to other`() {
+        val previousLocale = Locale.getDefault()
+
+        try {
+            Locale.setDefault(Locale.forLanguageTag("de"))
+            Localiser.configureDefaultLocalization("cs")
+
+            val result = Localiser.localisePlural("sample__section__fallback_count", 2, "2")
+
+            assertEquals("2 items-other", result)
+        } finally {
+            Locale.setDefault(previousLocale)
+            Localiser.configureDefaultLocalization("en")
+        }
+    }
+
+    @Test
+    fun `unsupported default localization language fails only on plural lookup`() {
+        val previousLocale = Locale.getDefault()
+
+        try {
+            Locale.setDefault(Locale.forLanguageTag("de"))
+            Localiser.configureDefaultLocalization("de")
+
+            assertFailsWith<IllegalStateException> {
+                Localiser.localisePlural("sample__section__item_count", 2, "2")
+            }
+        } finally {
+            Locale.setDefault(previousLocale)
+            Localiser.configureDefaultLocalization("en")
+        }
+    }
+
+    @Test
+    fun `malformed system localisation plural object fails during parsing`() {
+        val previousLocale = Locale.getDefault()
+
+        try {
+            Locale.setDefault(Locale.forLanguageTag("it"))
+
+            assertFailsWith<IllegalArgumentException> {
+                Localiser.localisePlural("sample__section__broken_count", 1, "1")
+            }
+
+            assertFailsWith<IllegalArgumentException> {
+                Localiser.localisePlural("sample__section__broken_count", 1, "1")
+            }
+        } finally {
+            Locale.setDefault(previousLocale)
+            Localiser.configureDefaultLocalization("en")
+        }
+    }
+}

--- a/linguine-runtime/src/jvmTest/resources/assets/strings-it.json
+++ b/linguine-runtime/src/jvmTest/resources/assets/strings-it.json
@@ -1,0 +1,5 @@
+{
+  "sample__section__broken_count": {
+    "one": "%1$d item"
+  }
+}

--- a/linguine-runtime/src/jvmTest/resources/assets/strings.json
+++ b/linguine-runtime/src/jvmTest/resources/assets/strings.json
@@ -1,0 +1,13 @@
+{
+  "sample__section__item_count": {
+    "zero": "%1$d items-zero",
+    "one": "%1$d item-one",
+    "two": "%1$d items-two",
+    "few": "%1$d items-few",
+    "many": "%1$d items-many",
+    "other": "%1$d items-other"
+  },
+  "sample__section__fallback_count": {
+    "other": "%1$d items-other"
+  }
+}


### PR DESCRIPTION
## Overview **Updated**:


This PR adds end-to-end plural localization support to Linguine and documents the generator/runtime contract around plural forms, placeholder indexing, provider export setup, and fallback language handling.

Before this change, localisation values were expected to be plain strings. Provider responses that contained plural objects could not be parsed or generated safely. The runtime also had no explicit language context for `strings.json`, which made plural form selection ambiguous for fallback assets.

## What Changed

### Generator

- Added support for plural JSON values alongside plain text values.
- Replaced loosely typed parsing structures with explicit `Translation` and `Node` models.
- Added `PluralFormPolicy`:
  - `REQUIRE_ALL_FORMS` is the default and requires all six Unicode CLDR plural forms: `zero`, `one`, `two`, `few`, `many`, and `other`.
  - `REQUIRE_OTHER_ONLY` allows provider integrations where only the fallback `other` form must be present.
- Generated plural values now produce `localisePlural(...)` accessors with `count: Number`.
- Placeholder parameters are generated from the full placeholder index set.
- For plural values, placeholder parameters are collected across all plural forms.
- All generated placeholder parameters are `String`; `count` is the only generated `Number` parameter.

### Runtime

- Added plural-aware runtime values via `LocalisationValue.Plural` and `LocalisationForms`.
- Added `Localiser.localisePlural(...)`.
- Added `LanguagePluralForm` with the full CLDR form set: `zero`, `one`, `two`, `few`, `many`, `other`.
- Added plural form selection for English, Czech, Slovak, French, and Spanish.
- Runtime plural selection now returns prioritized plural forms, not just a single form.
- This allows provider-required forms like `zero` and `two` to be preferred while still falling back to the language's grammatical form when appropriate.
- Example: Czech/Slovak `2` resolves as `two -> few`.
- Added explicit default localization language configuration for `strings.json`:

```kotlin
Localiser.configureDefaultLocalization("en")
```

- If `strings.json` is used without explicit configuration, Linguine keeps English as the default and logs a one-time warning.
- Runtime plural objects require `other` as the final fallback form.
- Unsupported plural-rule languages fail only when plural lookup is actually used.
- Plural counts must be finite; negative values are matched by absolute value.

## Placeholder Contract

Supported placeholders are `%s`, `%d`, `%f` and indexed variants such as `%1$s`, `%2$d`, `%3$f`.

- A single placeholder may be unindexed: `"Hello %s"`.
- If a string contains multiple placeholders, all of them must be indexed.
- Generated parameter indexes must be sequential from `1`.
- Plain string accessors derive parameters from the string itself.
- Plural accessors derive parameters from all plural forms together.
- `count` is only used to select the plural form; it is not automatically inserted into the output text.

## Provider / CLDR Contract

`REQUIRE_ALL_FORMS` is aligned with Unicode CLDR plural forms and requires all six forms:

```text
zero, one, two, few, many, other
```

The README now documents `Gettext-style equation for "n"` formulas for English, Czech, Slovak, French, and Spanish using that exact form order.

This is needed because providers such as Loco validate plural equations against the configured form slots. For example, when the `two` form exists, the provider expects `n = 2` to resolve to the `two` slot even for languages where the runtime later falls back to another grammatical form.

## Documentation

README was updated with:

- `pluralFormPolicy` configuration.
- Plural JSON and generated Kotlin examples.
- Placeholder indexing rules.
- Plural count behavior.
- `REQUIRE_ALL_FORMS` CLDR/gettext equation setup.
- Default localization language setup.
- Supported plural language extension notes.
- Known runtime/generator contract boundaries.

## Tests

Added and updated coverage for:

- Plural parsing policies.
- Full six-form `REQUIRE_ALL_FORMS` validation.
- Generated plural accessors.
- Placeholder parameter counting and indexing.
- Placeholder union across plural forms.
- Runtime plural formatting.
- Prioritized plural form fallback.
- Supported plural rules for English, Czech, Slovak, French, and Spanish.
- Default localization language behavior for `strings.json`.
- Unsupported plural-rule languages.
- Invalid plural objects.

Validation run:

```bash
./gradlew :linguine-generator:test :linguine-generator:functionalTest :linguine-runtime:check
```

## Known Considerations

- Unsupported printf-like placeholder tokens such as `%q`, `%1$q`, or `%1$` are outside the supported contract and should not be emitted by providers.
- Runtime JSON syntax errors are still logged and treated as empty localisation data for compatibility, while semantic localisation errors fail fast.
- Runtime formatting trusts templates to follow the generator contract. Assets that bypass generated accessors can behave differently from generator-validated templates.


<details><summary>Outdated Overview 2</summary>
<p>
This PR adds end-to-end plural localization support to Linguine and documents the generator/runtime contract around plural forms, placeholder indexing, and fallback language handling.

Before this change, localisation values were expected to be plain strings. Provider responses that contained plural objects such as `{ "one": "...", "few": "...", "other": "..." }` could not be parsed or generated safely. The runtime also had no explicit language context for `strings.json`, which made plural category selection ambiguous for fallback assets.

## What Changed

### Generator

- Added support for plural JSON values alongside plain text values.
- Replaced loosely typed parsing structures with explicit `Translation` and `Node` models.
- Added `PluralFormPolicy`:
  - `REQUIRE_ALL_FORMS` is the default and requires `zero`, `one`, `few`, `many`, and `other`.
  - `REQUIRE_OTHER_ONLY` allows provider integrations where only the fallback `other` form must be present.
- Generated plural values now produce `localisePlural(...)` accessors with `count: Number`.
- Placeholder parameters are generated from the full placeholder index set.
- For plural values, placeholder parameters are collected across all plural forms.
- All generated placeholder parameters are `String`; `count` is the only generated `Number` parameter.
- Kotlin identifier capitalization now uses `Locale.ROOT` to avoid default-locale casing issues.

### Runtime

- Added plural-aware runtime values via `LocalisationValue.Plural` and `LocalisationForms`.
- Added `Localiser.localisePlural(...)`.
- Added plural category selection for supported languages: English, Czech, Slovak, French, and Spanish.
- Added explicit default localization language configuration for `strings.json`:

```kotlin
Localiser.configureDefaultLocalization("en")
```

- If `strings.json` is used without explicit configuration, Linguine keeps English as the default and logs a one-time warning.
- Runtime plural objects require `other` as the fallback form.
- If the selected plural category is missing, runtime falls back to `other`.
- Unsupported plural-rule languages fail only when plural lookup is actually used.
- Plural counts must be finite; negative values are matched by absolute value.

## Placeholder Contract

Supported placeholders are `%s`, `%d`, `%f` and indexed variants such as `%1$s`, `%2$d`, `%3$f`.

- A single placeholder may be unindexed: `"Hello %s"`.
- If a string contains multiple placeholders, all of them must be indexed.
- Generated parameter indexes must be sequential from `1`.
- Plain string accessors derive parameters from the string itself.
- Plural accessors derive parameters from all plural forms together.
- `count` is only used to select the plural category; it is not automatically inserted into the output text.

## Documentation

README was updated with:

- `pluralFormPolicy` configuration.
- Plural JSON and generated Kotlin examples.
- Placeholder indexing rules.
- Plural count behavior.
- Default localization language setup.
- Supported plural language extension notes.
- Known runtime/generator contract boundaries.

## Tests

Added and updated coverage for:

- Plural parsing policies.
- Generated plural accessors.
- Placeholder parameter counting and indexing.
- Placeholder union across plural forms.
- `Locale.ROOT` identifier generation.
- Runtime plural formatting and fallback to `other`.
- Supported plural rules for English, Czech, Slovak, French, and Spanish.
- Default localization language behavior for `strings.json`.
- Unsupported plural-rule languages.
- Invalid plural objects.

Validation run:

```bash
./gradlew :linguine-generator:test :linguine-generator:functionalTest :linguine-runtime:check
```

## Known Considerations

- Unsupported printf-like placeholder tokens such as `%q`, `%1$q`, or `%1$` are outside the supported contract and should not be emitted by providers.
- Runtime JSON syntax errors are still logged and treated as empty localisation data for compatibility, while semantic localisation errors fail fast.
- Runtime formatting trusts templates to follow the generator contract. Assets that bypass generated accessors can behave differently from generator-validated templates.

</p>
</details> 

<details><summary>Outdated Overview 1</summary>
<p>
This PR adds end-to-end plural localization support to Linguine and makes fallback-language handling explicit for `strings.json`.

Before these changes, Linguine expected localization values to be plain strings only. That broke when the provider returned plural objects instead of strings.

This PR adds support for plural values in both the generator and the runtime, introduces language-specific plural selection rules, and makes fallback plural resolution for `strings.json` explicit and configurable.

## What Changed

### Generator

- Added support for plural JSON values alongside plain text values
- Introduced typed translation model:
  - `Translation.Text`
  - `Translation.Plural`
- Replaced the old loosely typed parsing flow with typed parsed nodes:
  - `Node.Group`
  - `Node.Item`
- Updated file generation so that:
  - plain strings still generate properties or parameterized functions
  - plural values generate functions using `localisePlural(...)`
- Generated placeholder parameters are now explicit `String` parameters:
  - `param1: String`
  - `param2: String`
  - etc.
- Plural accessors now use:
  - `count: Number`
  - explicit placeholder parameters as `String`

Example generated plural accessor:

```kotlin
fun itemCount(count: Number, param1: String, param2: String): String
```

### Runtime

- Added plural-aware runtime model:
  - `LocalisationValue.Text`
  - `LocalisationValue.Plural`
  - `LocalisationForms`
- Added `localisePlural(...)` to `Localiser`
- Added language-based plural selection in `LanguagePluralRules`
- Added supported plural language list in:
  - `LanguagePluralSupported`
- Added plural category enum in:
  - `LanguagePluralCategory`
- Implemented plural rules for:
  - `en`
  - `cs`
  - `sk`
  - `fr`
  - `es`
- Added support for fractional values via `count: Number`

### Plural object validation

Plural objects are now required to contain all five supported forms:

- `zero`
- `one`
- `few`
- `many`
- `other`

This is required because the external provider maps plural forms by position/index, so missing forms can shift the structure and break translation mapping.

### Fallback language handling

- `strings.json` remains supported for backward compatibility
- Added runtime configuration for the language of `strings.json`:

```kotlin
Localiser.configureDefaultLocalization("cs")
```

- If not configured explicitly, Linguine still defaults to `en`
- Added a one-time warning when `strings.json` is used without explicit default language configuration
- The warning now also points to the currently supported plural-rule languages
- `configureDefaultLocalization(...)` accepts any non-blank language code
- If plural lookup later uses a language that is not supported by `LanguagePluralSupported`, the runtime fails only when plural resolution is actually attempted

### Tests and docs

- Added and updated tests for:
  - plural parsing
  - plural generation
  - generated placeholder signatures
  - plural selection rules
  - fallback language behavior for `strings.json`
  - unsupported fallback language behavior during plural lookup
- Cleaned up test data to remove application-specific names
- Updated README with:
  - plural examples
  - explanation of default localization language
  - usage of `Localiser.configureDefaultLocalization(...)`
  - supported plural language source of truth
  - note that adding a new supported language also requires adding a rule in `LanguagePluralRules`

## How It Works

### 1. Localization JSON may now contain plain strings or plural objects

Example:

```json
{
  "catalog__title": "Catalog",
  "catalog__item_count": {
    "zero": "%1$s no items",
    "one": "%1$s item",
    "few": "%1$s items-few",
    "many": "%1$s items-many",
    "other": "%1$s items"
  }
}
```

### 2. Generator produces Kotlin accessors

Plain text:

```kotlin
val title: String = localise("catalog__title")
```

Plural text:

```kotlin
fun itemCount(count: Number, param1: String): String =
    localisePlural("catalog__item_count", count, param1)
```

### 3. Runtime selects plural form

Plural form selection is resolved:
- from the current language for language-specific files such as `strings-cs.json`
- from the configured default localization language for `strings.json`

### 4. Full plural form set is required

Plural objects missing any of the required forms are rejected during parsing:

- `zero`
- `one`
- `few`
- `many`
- `other`

## Plural Rule Behavior

Implemented behavior:

### English

- `0`, `0.0` -> `zero`
- `1`, `1.0` -> `one`
- everything else -> `other`

### Czech / Slovak

- `0`, `0.0` -> `zero`
- `1`, `1.0` -> `one`
- `2..4` -> `few`
- fractional values with non-zero fractional part, e.g. `1.5` -> `many`
- everything else -> `other`

### French

- `0`, `0.0` -> `zero`
- values in the configured `one` range -> `one`
- everything else -> `other`

### Spanish

- `0`, `0.0` -> `zero`
- `1`, `1.0` -> `one`
- everything else -> `other`

## Fallback Language Behavior

`strings.json` remains supported as the fallback localization file.

Because plural selection depends on language, `strings.json` needs an explicit language context when the source localization is not English:

```kotlin
Localiser.configureDefaultLocalization("en")
```

or:

```kotlin
Localiser.configureDefaultLocalization("cs")
```

If not configured explicitly:
- Linguine assumes `en`
- a warning is logged once when `strings.json` fallback is used

If a non-supported language code is configured:
- nothing fails immediately
- runtime fails only when plural resolution is actually attempted for that language
- the error message explains that plural rules must be added to the plugin/runtime

## Why This Change Is Needed

Without these changes:
- plural JSON objects caused parsing/generation failures
- plural selection could not work correctly for languages with multiple plural categories
- fallback `strings.json` had no explicit language context for plural resolution
- missing plural forms could shift provider-side mapping and break localization data

With this PR:
- plural provider data is supported end-to-end
- generated APIs remain explicit and easy to call
- fallback behavior is explicit and documented
- unsupported plural-rule languages fail with an actionable error only when plural logic is actually used

## Intentional decisions

- plural objects must contain all five required forms:
  - `zero`
  - `one`
  - `few`
  - `many`
  - `other`
- plural accessors use `count: Number`
- generated placeholder arguments are explicit `String` parameters
- placeholder arguments remain independent from `count`
- `strings.json` is preserved for compatibility
- unsupported plural-rule languages fail only when plural localization is actually used
</p>
</details>


<details><summary>Outdated Overview 0</summary>
<p>

## Overview

This PR adds plural localization support to Linguine end-to-end and makes fallback language handling explicit in the runtime.

Before these changes, the generator/runtime expected every localization value to be a plain string. That broke as soon as the provider returned plural objects such as:

```json
{
  "sample__section__item_count": {
    "one": "%1$s item",
    "few": "%1$s items",
    "other": "%1$s items"
  }
}
```

In addition, fallback localization had no explicit language context, which made plural selection ambiguous for `strings.json`.

This PR fixes both problems.

## What Changed

### Generator

- Added support for plural JSON values alongside plain text values.
- Introduced `TranslationEntry` with:
  - `Text`
  - `Plural`
- Replaced the old loosely typed `Map<String, Any>` / `Pair` parsing flow with typed parsing structures:
  - `ParsedLeaf`
  - `ParsedNode.Group`
  - `ParsedNode.Leaf`
- Updated file generation so that:
  - plain strings still generate properties or parameterized functions
  - plural values generate functions using `localisePlural(...)`
- Generated plural accessors now look like:

```kotlin
fun itemCount(count: Number, vararg args: Any): String
```

### Runtime

- Added plural-aware runtime model:
  - `LocalisationValue.Text`
  - `LocalisationValue.Plural`
  - `LocalisationForms`
- Added `localisePlural(...)` to `Localiser`
- Added plural selection rules in `LanguagePluralRules`
- Added supported plural categories enum:
  - `zero`, `one`, `two`, `few`, `many`, `other`
- Implemented plural rules for:
  - `en`
  - `cs`
  - `sk`
- Added support for fractional values via `count: Number`
- Added required fallback validation for plural objects:
  - `other` must always exist

### Fallback language

- Kept backward compatibility with `strings.json`
- Added explicit runtime configuration for the language of `strings.json`:

```kotlin
Localiser.configureDefaultLocalization("cs")
```

- If not configured, runtime defaults to `en`
- Added one-time warning when `strings.json` is used without explicit default language configuration

### Tests and docs

- Added/updated tests for:
  - plural parsing
  - plural generation
  - plural selection rules
  - fallback language behavior for `strings.json`
- Cleaned up test data to remove application-specific names
- Updated README with:
  - plural example
  - explanation of `default localization language`
  - usage of `Localiser.configureDefaultLocalization(...)`

## How It Works

### 1. Provider JSON can now contain either strings or plural objects

Example:

```json
{
  "catalog__title": "Catalog",
  "catalog__item_count": {
    "one": "%1$d item",
    "other": "%1$d items"
  }
}
```

### 2. Generator produces Kotlin accessors

- plain text:

```kotlin
val title: String = localise("catalog__title")
```

- plural text:

```kotlin
fun itemCount(count: Number, vararg args: Any): String =
    localisePlural("catalog__item_count", count, *args)
```

### 3. Runtime selects plural form

- based on current language for language-specific files
- based on configured default localization language for `strings.json`

### 4. `other` is mandatory

- plural objects without `other` are rejected during parsing

## Plural Rule Behavior

Implemented behavior:

### English

- `1`, `1.0` -> `one`
- everything else -> `other`

### Czech / Slovak

- `1`, `1.0` -> `one`
- `2..4` -> `few`
- fractional values with non-zero fractional part, e.g. `1.5` -> `many`
- everything else -> `other`

This matches the runtime contract we want to support for downloaded plural forms.

## Fallback Language Behavior

`strings.json` remains supported as the fallback localization file.

Because plural selection depends on language, `strings.json` now needs an explicit language context. This PR introduces runtime configuration for that:

```kotlin
Localiser.configureDefaultLocalization("en")
```

or for another source language:

```kotlin
Localiser.configureDefaultLocalization("cs")
```

If not configured explicitly:

- Linguine assumes `en`
- a warning is logged once when `strings.json` fallback is used

This keeps existing clients working while making the behavior explicit for non-English source localizations.

## Why This Change Is Needed

Without these changes:

- plural JSON objects caused parsing/generation failures
- plural selection could not work correctly for languages with multiple plural categories
- fallback `strings.json` could be interpreted using the wrong plural rules

With this PR:

- plural data from providers is supported end-to-end
- generated APIs remain simple to call
- fallback behavior is explicit and documented

## Important intentional decisions:

- `other` is required for every plural object
- plural accessor uses `count: Number`
- placeholder arguments are independent from `count`
- `strings.json` is preserved for compatibility instead of being removed
- unsupported plural-rule languages fail only when plural localization is actually used, with an explicit actionable error message


</p>
</details> 
